### PR TITLE
chore: update to polkadot v1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "binary-merkle-tree"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf857f8f411164ce1af14a778626af96251de7a77837711efbc440807e7053f"
+checksum = "4b5c0fd4282c30c05647e1052d71bf1a0c8067ab1e9a8fc6d0c292dce0ecb237"
 dependencies = [
  "hash-db",
  "log",
@@ -888,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "bp-xcm-bridge-hub-router"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ff4abe93be7bc1663adc41817b1aa3476fbec953ce361537419924310d5dd4"
+checksum = "1c4f6632dc163635dac350d682f84513e506d8b156a6e936ed531586cf83624c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1407,7 +1407,7 @@ dependencies = [
  "gimli 0.27.3",
  "hashbrown 0.13.2",
  "log",
- "regalloc2",
+ "regalloc2 0.6.1",
  "smallvec",
  "target-lexicon",
 ]
@@ -1594,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-cli"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d2597fe3235d263457aaff65d0fb5bed506698b81530e2e6afecd6d6c9af32"
+checksum = "f7973210fbe9e3aa9e0c3526a640e53ca4d337edd831bba36ad95477f15be2d6"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1612,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-collator"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c06ae72a125d056da3b722f00f87881a2afbb2af8fe9fa9a91587f139b9667e"
+checksum = "dcc86757baaf304dc5e31f4258494cb555684b1192880f099c1804461afd9c76"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1636,9 +1636,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-aura"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f4977f6a88af39c46832d571ac0d95e8322bf22eab42550fec34f72da9f034"
+checksum = "38090a161c97a592632642de9937536031f400a6342167fb694459e7d7a0868f"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1679,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-common"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350db1fc8841a44f344474b791d2ebe61b79bf6061043a7d826b3d02d1935a56"
+checksum = "d1b4650279485c065ef0d320fe3eca76c28b118884985aedf6bfc9a4a567efae"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1709,9 +1709,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-proposer"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38028f75597a34d447f059d6a7fd9c1c91bce0b8c48b08b1cbd19eb3def9c376"
+checksum = "f09f56940da9f0479a7a4a823c1d6abf772263efeb6de60eb54a414816031ee7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1725,9 +1725,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-network"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ac095ef439c595ccb998be5a9d40778d8963c5a8ebbaed838fed6293232915b"
+checksum = "2b07a201d4bdbbe3a704fb24401e95320ca8f4d36a6b21dd16b6e64ea9fc2f53"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1749,9 +1749,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-parachain-inherent"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b516290cd4a6efc117824135761f3642dc57685e13da00727c460053ce978fe"
+checksum = "f691d5c3cd55f18d377b171c37d388f60c8cc86b123dde2419b0995e21f114cb"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1774,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-pov-recovery"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d55e96004ca9aa9d9b96a28ab2d97b1ca8d303c9d2405ea34cdf1462d4c4f0"
+checksum = "4169440db89a04618d9a030d9443171b865649d298e27b087604a0b9f70ffa8f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1799,9 +1799,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-service"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "657f57c56159bb6cb74d9221de8f11c9e09962666381357896562662d3019799"
+checksum = "b1b5b0f16d370cb4bdb1db6ef852a121607441b2ffe98603de5961d35feb187b"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -1836,9 +1836,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-aura-ext"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8e78b18548ae3454bc8a46e2bc2e3f521ea547844cbaecc9344d4741f4b1ef"
+checksum = "9c8c0f09547fdc04119cf10f7c7fef2365e50c4ebb994501ff49c59b4513d860"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -1855,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a215fe4d66d23e8f3956bd21b9d80d2b33239f3b150b36d56fa238cfc9421a5"
+checksum = "60ed4784ab971a10b3b5d4094e6dd391a994ac9d5f48ee18cb1db1fe5b2b1e4a"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -1903,9 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3259f743f70f39baa3abf2d9d8de864e18120465f8731b99bef039a3bf9329"
+checksum = "07d60332d340bbf286af82553bd497bc958985b883c7e71a2cbb46ac8e814adb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1918,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-xcm"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e802291060763f8d1176bf808da97aafe5afe7351f62bb093c317c1d35c5cee"
+checksum = "0ff39e7420c30c2f1d528e254e993e21414c4a3c01f90d7c2e6dcfbd19049c18"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1935,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa22d6e479a4d3a2790bab291269ba0917a1ac384255a54a2ebc3f7c37e505e"
+checksum = "753e8fcd97b3ae801bad71b2909c1e323683c0c49f7c92b2b3766ab58189a45f"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -1961,9 +1961,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-aura"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f07d6177692154043d7ddcc0b87ca5365ae8e4d94b90d9931f6b2f76e162f09"
+checksum = "14b362f87e3fe8c8bd4c2b95fe4f8fcf601d1cf134c2c584297fdce18d8f60eb"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -1976,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-core"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df07f6825fd50ea30aae335e43dc1a615a05de7465f5f329b9e414f2c886a12"
+checksum = "855c15fa25c6b55446e1c07f5cc830cfc0547e4d6d2b46b66dc28b088e69db75"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -1994,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ad140a065a6b8001fb26ec42b91391e90fde120f5b4e57986698249a9b98c8"
+checksum = "c4043915fbee54cc0acc83450f035989aa2e1170210e9e6d7fc2a5773cd81eef"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2010,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b74f9141190b9f4bf96a947ade46da64097b77f1ebfa8d611c81724250e119"
+checksum = "d7034e98f0883e9f5601063c7d252406ee5cc9c98090635e33fa3070bfcb62cb"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2021,9 +2021,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-utility"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e65466e56d642f979b556d098a03755ae51972fff5fa0f9b1cdcfdb3df062ea3"
+checksum = "6dc4ccf3de0ffcd12b50954651421074699c4e103d9e17b8cb90265b2a72abcc"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2042,9 +2042,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff27dec2eab6cd1d854756d62bd7053721ccd115f36f9e8b0976b1e46b70ef7"
+checksum = "bf009edca50d0be7e7408c16482dc2f389cfcf5d490c0e4700d41f9487ddd86f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2067,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-interface"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c736f39b50eecf194707e15d0359677bb8fe8138b01f6493ab9b7e10d2d1ae"
+checksum = "5d70b6d323b475b48c5e5cb215b032d685683d5c94ae9a4e808fb171b88a5e66"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2086,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7718fe298d567adc44fae3dd7024418d6eff08264041e4b0544d1892861cd6"
+checksum = "689c2b0c1fc49c58e5d51faa45ae361f993f8d0f313abeab1990ac58c10cbcbd"
 dependencies = [
  "array-bytes 6.2.2",
  "async-trait",
@@ -2128,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e2269d4c1f37593257b3d7b90f8b56adab0793d9b9f5c1b5334c9ca7e3b10b"
+checksum = "a094c62e40c3731c7cb4a0a78f80bbbe73e665e0bf367a28213e68d5b80a8ba3"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2168,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfff604ad01c5c0c397f9a971c8cec6443aea3658813778875b4f64de07847d5"
+checksum = "b934962b9161c12a09521d2919cec1923a9dc7361beae6850e627c9da99c807c"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -2277,6 +2277,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.52",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.9",
 ]
 
 [[package]]
@@ -2812,6 +2825,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2985,9 +3004,9 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frame-benchmarking"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4090659c6aaa3c4d5b6c6ec909b4b0a25dec10ad92aad5f729efa8d5bd4d806a"
+checksum = "34134abd64876c2cba150b703d8c74b1b222147e61dbc33cbb9db72f7c1cdb2f"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3011,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe02c96362e3c7308cdea7545859f767194a1f3f00928f0e1357f4b8a0b3b2c"
+checksum = "e618a6cbce60ed9a94850b2cb7d08a08e391ee0f287ee20082430da2d385916b"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.2",
@@ -3072,9 +3091,9 @@ dependencies = [
 
 [[package]]
 name = "frame-election-provider-support"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87da19ee99e6473cd057ead84337d20011fe5e299c6750e88e43b8b7963b8852"
+checksum = "53ff3c76750b481f9fd633ccddeed955426adc28aee566dd7233b7ac22cda9f5"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3090,9 +3109,9 @@ dependencies = [
 
 [[package]]
 name = "frame-executive"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09bff9574ee2dcc349f646e1d2faadf76afd688c2ea1bbac5e4a0e19a0c19c59"
+checksum = "9d4542ef9abae48cb665f9992ece20ecded914ecfdaafb3f76968c645358b8df"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3121,9 +3140,9 @@ dependencies = [
 
 [[package]]
 name = "frame-remote-externalities"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360bfdb6821372164a65933d9a6d5998f38c722360b59b69d2bf78a87ef58b2a"
+checksum = "2e11f19ac2855385880d96366287a52fa4cc513e2d5ec53b891a5f7ac7be2a71"
 dependencies = [
  "futures",
  "indicatif",
@@ -3144,9 +3163,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b24824d29c43d0af94be3356bbf30338ededed649f6841d315a9ae067ce872"
+checksum = "40bde5b74ac70a1c9fe4f846220ea10e78b81b0ffcdb567d16d28472bc332f95"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.2",
@@ -3186,9 +3205,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "24.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf1d648c4007d421b9677b3c893256913498fff159dc2d85022cdd9cc432f3c"
+checksum = "c762bf871c6655636a40a74d06f7f1bf69813f8037ad269704ae35b1c56c42ec"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3206,9 +3225,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3363df38464c47a73eb521a4f648bfcc7537a82d70347ef8af3f73b6d019e910"
+checksum = "5be30b1ce0b477476a3fe13cd8ff479007582340d14f0ddea9e832b01e706a07"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -3219,9 +3238,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68672b9ec6fe72d259d3879dc212c5e42e977588cdac830c76f54d9f492aeb58"
+checksum = "ed971c6435503a099bdac99fe4c5bea08981709e5b5a0a8535a1856f48561191"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3230,9 +3249,9 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc20a793c3cec0b11165c1075fe11a255b2491f3eef8230bb3073cb296e7383"
+checksum = "c302f711acf3196b4bf2b4629a07a2ac6e44cd1782434ec88b85d59adfb1204d"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3251,9 +3270,9 @@ dependencies = [
 
 [[package]]
 name = "frame-system-benchmarking"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac47ee48fee3a0b49c9ab9ee68997dee3733776a355f780cf2858449cf495d69"
+checksum = "e41213421daaf14370e6d59016bd1be5e8d8c990bb336b72e72b3c60d874d3df"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3267,9 +3286,9 @@ dependencies = [
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1b20433c3c76b56ce905ed971631ec8c34fa64cf6c20e590afe46455fc0cc8"
+checksum = "7b48b28339a07bb7e797d3546c29600dd0b7c97ffd9d6642665dc96d81c0b475"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3277,9 +3296,9 @@ dependencies = [
 
 [[package]]
 name = "frame-try-runtime"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eab87d07bc2f9a2160b818d1b7506c303b3b28b6a8a5f01dc5e2641390450b5"
+checksum = "3be404b49a2c947a77ec813b372ca5119182f8de131ee98a5656bc1043958b8b"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3545,7 +3564,7 @@ version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 dependencies = [
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "indexmap 1.9.3",
  "stable_deref_trait",
 ]
@@ -3555,12 +3574,36 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+dependencies = [
+ "fallible-iterator 0.3.0",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "governor"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot 0.12.1",
+ "portable-atomic",
+ "quanta",
+ "rand",
+ "smallvec",
+ "spinning_top",
+]
 
 [[package]]
 name = "group"
@@ -3833,9 +3876,9 @@ dependencies = [
  "hyper",
  "log",
  "rustls 0.21.10",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -4131,9 +4174,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.20.3"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "affdc52f7596ccb2d7645231fc6163bb314630c989b64998f3699a28b4d5d4dc"
+checksum = "3cdbb7cb6f3ba28f5b212dd250ab4483105efc3e381f5c8bb90340f14f0a2cc3"
 dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-http-client",
@@ -4147,19 +4190,20 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.20.3"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b005c793122d03217da09af68ba9383363caa950b90d3436106df8cabce935"
+checksum = "9ab2e14e727d2faf388c99d9ca5210566ed3b044f07d92c29c3611718d178380"
 dependencies = [
  "futures-util",
  "http",
  "jsonrpsee-core",
  "pin-project",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.0",
+ "rustls-pki-types",
  "soketto",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "tokio-util",
  "tracing",
  "url",
@@ -4167,12 +4211,12 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.20.3"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2327ba8df2fdbd5e897e2b5ed25ce7f299d345b9736b6828814c3dbd1fd47b"
+checksum = "71962a1c49af43adf81d337e4ebc93f3c915faf6eccaa14d74e255107dfd7723"
 dependencies = [
  "anyhow",
- "async-lock 2.8.0",
+ "async-lock 3.3.0",
  "async-trait",
  "beef",
  "futures-timer",
@@ -4180,21 +4224,22 @@ dependencies = [
  "hyper",
  "jsonrpsee-types",
  "parking_lot 0.12.1",
+ "pin-project",
  "rand",
  "rustc-hash",
  "serde",
  "serde_json",
- "soketto",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.20.3"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f80c17f62c7653ce767e3d7288b793dfec920f97067ceb189ebdd3570f2bc20"
+checksum = "8c13987da51270bda2c1c9b40c19be0fe9b225c7a0553963d8f17e683a50ce84"
 dependencies = [
  "async-trait",
  "hyper",
@@ -4212,28 +4257,29 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.20.3"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29110019693a4fa2dbda04876499d098fa16d70eba06b1e6e2b3f1b251419515"
+checksum = "1d7c2416c400c94b2e864603c51a5bbd5b103386da1f5e58cbf01e7bb3ef0833"
 dependencies = [
  "heck",
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.20.3"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c39a00449c9ef3f50b84fc00fc4acba20ef8f559f07902244abf4c15c5ab9c"
+checksum = "4882e640e70c2553e3d9487e6f4dddd5fd11918f25e40fa45218f9fe29ed2152"
 dependencies = [
  "futures-util",
  "http",
  "hyper",
  "jsonrpsee-core",
  "jsonrpsee-types",
+ "pin-project",
  "route-recognizer",
  "serde",
  "serde_json",
@@ -4248,23 +4294,22 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.20.3"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be0be325642e850ed0bdff426674d2e66b2b7117c9be23a7caef68a2902b7d9"
+checksum = "1e53c72de6cd2ad6ac1aa6e848206ef8b736f92ed02354959130373dfa5b3cbd"
 dependencies = [
  "anyhow",
  "beef",
  "serde",
  "serde_json",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.20.3"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca9cb3933ccae417eb6b08c3448eb1cb46e39834e5b503e395e5e5bd08546c0"
+checksum = "c8a07ab8da9a283b906f6735ddd17d3680158bb72259e853441d1dd0167079ec"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
@@ -5201,9 +5246,9 @@ dependencies = [
 
 [[package]]
 name = "mmr-gadget"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f62cddc29c17965ab16a051a745520d41c28d8b4c2b6188aaf661db056d67c9"
+checksum = "5bc2f5c2f4d5e8ad1c275708b7d7e23fa2812cc94e3591b864d9d89f96b3fea4"
 dependencies = [
  "futures",
  "log",
@@ -5221,9 +5266,9 @@ dependencies = [
 
 [[package]]
 name = "mmr-rpc"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2634b45039e064c343a0a77ed45e03ca027c84e1b250b2f3988af7cde9b7e79e"
+checksum = "93c2b8a657edbe89a72f0d95e31d7f31837035a067f0316499aaa9bddf6dda78"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -5542,6 +5587,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5568,6 +5619,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "normalize-line-endings"
@@ -5762,9 +5819,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-conversion"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4079f12db3cf98daa717337ab5b7e5ef15aa3bec3b497f501dc715d129b500da"
+checksum = "c423381a64cf1d9ee7b5d6be968e4b94019a7b993ba8c92eca5842bfdba40651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5781,9 +5838,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-rate"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571ce57fd846911041749832b46a8c2b01f0b79ffebcd7585e3973865607036d"
+checksum = "561cfeb28ce89a79f4e1663a44724a1f551536bd41c1d2c6e66432480f948f68"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5797,9 +5854,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-tx-payment"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed783679921ad8b96807d683d320c314e305753b230d5c04dc713bab7aca64c"
+checksum = "6530bad86d493df89539037e6dca0114d979f8e6c3c9f0c704ff6ee2dc6df676"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5816,9 +5873,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-assets"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46728a98a910af13f6a77033dd053456650773bb7adc71e0ba845bff7e31b33e"
+checksum = "7c54b67fb2fab83382f7cd860aa5e0e0d478c914f81b87a7c24df2d93f740a89"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5833,9 +5890,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-aura"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a611bef3c8cf281e41a43f32a4153260bdc8b7b61b901e65c7a4442529224e11"
+checksum = "9b1085f847e49c5a56d4a7f87815f4ac6d37cd7e3997e2444abc105e2207aeca"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5851,9 +5908,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "29.0.1"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd9a381c613e6538638391fb51f353fd13b16f849d0d1ac66a388326bd456f1"
+checksum = "485ca0e15ffc8c60d8e101112f3ce26fe139582f7416e2697955b63f478cf038"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5868,9 +5925,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-authorship"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d83773e731a1760f99684b09961ed7b92acafe335f36f08ebb8313d3b9c72e2"
+checksum = "aa1f02863403c1cf5e9f49fd492c8cdb329d4b45029f3f19f278b3ba832a2b81"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5883,9 +5940,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-babe"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3f2020c52667a650d64e84a4bbb63388e25bc1c9bc872a8243d03bfcb285049"
+checksum = "b91a0fdb62c2d72c3c680deca50121d4bf2d8ed4b24dedd85f5b98ac454e781b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5908,9 +5965,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-bags-list"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd27bfa4bfa5751652842b81241c7eff3e68f2806d9dacc17b03d2cb20a39756"
+checksum = "69670ec14dc7b2c1cc0786a7cec891d1c7e0e2ce67e155721dd493cb3096b50b"
 dependencies = [
  "aquamarine",
  "docify",
@@ -5931,9 +5988,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942007f4f7aace74b77009db1675e7ca98683a42dde5e2d85bba2a9f404d2e5a"
+checksum = "f68b79a1f9f10c63377177155a4ac3ac08db356027a3d8bc826e1af65c885b8d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5948,9 +6005,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-beefy"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bedd80e9d8b196f31ea134efd271fdc1b8380ca3aa2d8af6ea8b5a0dc4fa460"
+checksum = "2f32bf6b3fec18e3ad0831e98e39857e2be1a8c3c240b978930f98f6df82cfa7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5969,9 +6026,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-beefy-mmr"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d334f24d3c0c016d16aa87d069485847d622e8ebebace18ec5cf56609ca3a67"
+checksum = "c960ba2f8be1e52f238ccf2e7bffb5b96adf8d15fb19ac24ac01571c4b61954a"
 dependencies = [
  "array-bytes 6.2.2",
  "binary-merkle-tree",
@@ -5995,9 +6052,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-bounties"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4765879e96676c13cdbed746d66fd59dcde1e9e65fda1f064fa2fffa3bc5d597"
+checksum = "abeb09ea0290befa44738288c5dfe72ed9b21ec5e3c5d7e82e081376f1c029be"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6014,9 +6071,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-broker"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8cfe04e8c3f9ca8342ac785f2b1aee6140e1809546fc6f3a99fad20a8dfbf9"
+checksum = "16828306edf66de7412d769f4716fd54f9046713e8e63a774f75814c9ca7a898"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -6032,9 +6089,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-child-bounties"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00fd06f2d719f5bb16ab3e836c6b053bbd92631ba694f8c2bf810013b2548167"
+checksum = "d309cc33a3cc3485527faf3429e2f776dd64311d031d330d079444231f85c5c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6052,9 +6109,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-collator-selection"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5ad46601c613396e92292a24c5b5d76e904c456ece9deb10913f6ea2e2999"
+checksum = "549c2cd295f297572469fc033eca4fb74e8725f26de5ac22e9ae16f7db56561e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6072,9 +6129,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-collective"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c362a0b8f30895c15ecc7d8c24b0d94bb586c4b9bbd37ac8053b4629d9cc80b"
+checksum = "3241a9f6ba5fde426bc306ae514550377f3407dcfcc351d47e9fff297ccde6a0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6090,9 +6147,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-conviction-voting"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aee3a8b6fcde893f862993f9d45eb0fcd492dde0967fd56ef78d79fc7b53dc0"
+checksum = "bb246d7cb84a78d1847770cf7c76e52d8b85dc80e8b6cd34414f9cbae0f5511f"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6108,9 +6165,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-democracy"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa781d632063087bcd3ff46eb1a668f15647ab116f1c8a7c573b7168f62d72c3"
+checksum = "247fc95fd76eff387678b251f56ea6832df0dcd55269cd76fe1b8a9fa888d0f4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6127,9 +6184,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-election-provider-multi-phase"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b54d1d3fe9ae61a144d581147e699b7c3009169de0019a0f87cca0bed82681e7"
+checksum = "ea7ebcb00352d6a814f3f92ed702a898eb4d78edba740930f97b6a38e577f820"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6151,9 +6208,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ec87816a1e32a1ab6deececa99e21e6684b111efe87b11b8298328dbbefd01"
+checksum = "9c57509f5a4fd41a953c2e29813a2ba09f30a5bf59c5f98bfcbb7c2619b7d931"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6166,9 +6223,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cb0158cc7461fda5db04c5791d0df34635bec37181763aca449bade677d12d"
+checksum = "be4cdc5615ff4651a9e85f980781b0023fff25572130006cd73bf287b7c160b3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6186,9 +6243,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-fast-unstake"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2222607a0dba10a9d57cab5360a6549b5fda925181c3c7af481246c0964998df"
+checksum = "09c915f2da843cd2bfbdbe6379624c94e1e93296488f17be4e380a7086b59cf9"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6206,9 +6263,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-grandpa"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b20be8592eed7ebca2ee661fc43450088552ebe0bd483d7b101cf5968ab12d"
+checksum = "16b22d7b2ad0fa9811c441051cc90792924d58fe6d0cfeff8db231da68fcc9fa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6230,9 +6287,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-identity"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e1cae19e30e7dc822c419988b30bb1318d79a8d5da92733822d0e84fe760ca"
+checksum = "04f0a43b8d840ffd170fa05e277160dedfafa10c83cb39089afcce571fed5e08"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6248,9 +6305,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-im-online"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598ea5c87351edc953d1f455f32ff456cf2f1daf7bbada1f1e03be8e384852ab"
+checksum = "57205599c150041e666cbdb53300201de5378b603f12d1efcf7dfa8d61fd8829"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6269,9 +6326,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-indices"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e880ebdb429ca76fb400b1b361ed7fce018a5ea2fc2da4764de5156fffdfa73"
+checksum = "97b5330b6bed6d82e0aa9ae18af0f8ce1f79cf86cf7cb49efc38920a652ad948"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6287,9 +6344,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-membership"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad901cdf3de23daf23ff8b092ab318b13faebfc1aa4d84263f2fdc84feaf3e9b"
+checksum = "db551d8d3fec5f7b584db0b28af396412e25bb0ae0e018c3cb75761efc71115c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6305,9 +6362,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-message-queue"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccb23dee70b184a214d729db550117a0965a69107d466d35181d60a6feede38"
+checksum = "31856e2c797c6a262c22b63ce195901ef48b66d7b80a8a1d0f3b5f1c88a51332"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -6326,9 +6383,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-mmr"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f1f23a70764dad2b4094d8be12ebbb82df210f2e80dd36fa941a5ac191c6cd"
+checksum = "992df88910f526671b357d9269a5c7d6c8ab025ee7126fce897d2869e2059390"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6345,9 +6402,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-multisig"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176f6a5c170185f892a047c0ae189bc52eb390f2c0b94d4261ed0ebc7f82a548"
+checksum = "5e06afee42c1b10c172500e3c455543ecaae7c7f3aa9631e23a66d82547f6108"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6362,9 +6419,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-nis"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a64a0e80dec2c60d5962dd249061a47dc4356db440f26cdec50b8acaded1d3"
+checksum = "71526b32ab454e10db38f35aff90ed5d537962597e1aa9cc9211c8020e566e85"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6379,9 +6436,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f14519c1c613d2f8c95c27015864c11a37969a23deeba9f6dbaff4276e1b81c"
+checksum = "6f327bb93b56ce995d95eaf05b1bfc6b23a453b9412aa41ff6d362dff722413c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6399,9 +6456,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a1eba3078e2492cad15e4695f90eb3fc570386d9f71f8b81f709c7123fc6b5"
+checksum = "1f4c7bb170227cbbfcc8d1795cb0e2053c79a1d2738c5f85b13afee151e2d334"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6420,9 +6477,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "24.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5b35e6c471a669437b987ff02e11e2283412c9ebaeec5334dec3f73bcea652"
+checksum = "4eb2bb3ab695ec7e79a668823bfa63329fd087f02ce707316f8f33fe7c5577e6"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -6432,9 +6489,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b5bcfdc4f6032d7570929094fd459de12d840c440c395fb4d365d679e13eda"
+checksum = "7e2f06e9da4dff8765a4bbae81b06932ff6ab8f0197d26497a5edd2b58efa303"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6450,9 +6507,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences-benchmarking"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc33e3086c19235cb903cbbbde1bc1c4f428519ad4c23446dc84c75d0061582"
+checksum = "812bc221afa5d12ff341455a1d62a2516e734af84324433392c8b2923d89d80b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6475,9 +6532,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-preimage"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7344a30c304771beb90aec34604100185e47cdc0366e268ad18922de602a0c7e"
+checksum = "a8573ce5aad3f488b2565707624c675c25af8b67d6ece102565d9fdbf57eaed8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6493,9 +6550,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-proxy"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7aa31a0b91e8060b808c3e3407e4578a5e94503b174b9e99769147b24fb2c56"
+checksum = "f3d6b9f7210b6cd4dcf531c1f8729eaeb7dfbed8e8b1b01b1747240b0f8a715d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6509,9 +6566,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-ranked-collective"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3733dbfc44d8f5e1a08287a9064e5794e9d0e92b1bd68cdad2e22202b1964528"
+checksum = "e06d19491f9a6a0cde4ba3e6c02d8366af60efea8fbf9ffb27ca674b1ecca622"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6529,9 +6586,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-recovery"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797b554ddc87082c18223440d61a81cf35ccab6573321ce473a099e7a709a760"
+checksum = "786d77701ccba3306b0c4bf8a2c3d2f160723eb219db7e2248cf505e5cdb86f6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6545,9 +6602,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-referenda"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da850889e7101b63cadb980b7f39df67feb6d63bc6092769b9b708e9eb596db1"
+checksum = "6866372ff2428967876e906c725b97a4b32612c9a2a9d9c3c1478c7060ea5ff6"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6565,9 +6622,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-root-testing"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59171cbf2b823c13685b1b80dd3e1e84425680ff4e006d8016f8c14d2ec44974"
+checksum = "eec41db5afabcc945d98ce427980faa56a867bdcd40133e662cf96546ff951de"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6581,9 +6638,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-scheduler"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e2a4ebe6a5f98b14a26deed8d7a1ea28bb2c2d3ad4d6dc129a725523a2042d"
+checksum = "5daf9f2a35fb6902011fc66e0d8c9831acd86512a78f298b52aba4970b121075"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6600,9 +6657,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-session"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7412ac59247b300feee53709f7009a23d1c6f8c70528599f48f44e102d896d03"
+checksum = "42218759d10405996ae378968751a9b1142b47f6b887562f2df50cc14b1c7eaa"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6623,9 +6680,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c2731415381020db1e78db8b40207f8423a16099e78f2fde599cbcb57ea8db"
+checksum = "aafe03e451af13c599da6f2cca66e20a5c0b522b31ad7c35d6a1a261081a2f70"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6641,9 +6698,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-society"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba64f96619c25ae7a0b41f4a5111c2d3102e8b8c6cbce80ece6955e825f9de2"
+checksum = "e3ce9f43cb5d254f17a3f747b5aa4ecfaace31d765bd102a4b4b2565b8353c3a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6660,9 +6717,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "29.0.0"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a94127295cf027a26e933ea6788b0824e9fedd90740013673e2d36b5d707efe"
+checksum = "2ecac33e40ab13bdf6994f4d769fea2536a4318c44a5cb865ce1034e9a982753"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6696,9 +6753,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-reward-fn"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505d45e08bad052f55fb51f00a6b6244d23ee46ffdc8091f6cddf4e3a880319d"
+checksum = "1e341c47481040b68edcf166ad34633c4c5da20d1559413e68387da935a6ae18"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -6706,9 +6763,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-runtime-api"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237d7b5a10cb6cba727c3e957fb241776302aa3cce589e6759ba53f50129c1a5"
+checksum = "2773af1f9c4c4d70ec9a0a4feed15ac47355544aee9520c2901d751eef644cef"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6717,9 +6774,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-state-trie-migration"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e52dedc146b7a9c3b7c5a6ff4c4c442a8ab8cc58ec30e90e1e98cdc51ad34"
+checksum = "99e81be14eff1fa562bb0b9af69932e91803d9e5c63888ad9c390741a7906058"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6735,9 +6792,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-sudo"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d02f7855d411913e77e57126f4a8b8a32d90d9bf47d0b747e367a1301729c3"
+checksum = "78e1b72aeabc9f0ba731229ccef31d8e5a160faae5edf2651a8cdacaa2690124"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6752,9 +6809,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-timestamp"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b8810ddfb254c7fb8cd7698229cce513d309a43ff117b38798dae6120f477b"
+checksum = "c307589adc04a0d578ae00231bc04f1a53ef07a0aa2f3e9d4c7e4bf419bf6e3d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6773,9 +6830,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-tips"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca4b9921c9e9b59e8eeb64677ba6ec49743ef5fe98e0b63f77411b2b9f6cc99"
+checksum = "efa45c34750ebd677c4d449695e84cc25c1ce5b9eea531332d1c60e22b69ff01"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6793,9 +6850,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f690f5c287ad34b28ca951ef7fae80b08cc9218d970723b7a70e4d29396872"
+checksum = "6d598d0ad779d19fa44ce6f80c57192537fa9f84995953bf2a8c104b7676b6b7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6810,9 +6867,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ef209d2d5d077e325bf49b024fd2eff109a5c2ca0d84ce0d50a65839e6b026"
+checksum = "c4fac4e459db3c002ddebfbce82d055dbe8885eb4c2f9dcd9da5675eafef9bb7"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6827,9 +6884,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c78bcba80c7c61712b98a6b5640975ebd25ceb688c18e975af78a0fac81785b0"
+checksum = "4d34487aec13e174906b6bba112f672e72948d16b8ee0752b8bebd659ac528dc"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6840,9 +6897,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-treasury"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1605eb5083a2cd172544f33c6e59eca2e23ac49f02f13d1562b1b8a409df9c60"
+checksum = "317d231ff8a773e94fe5be8d3710213215208e7993bfeedd96bd6f4402da114a"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6860,9 +6917,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-utility"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954f15b98c3fdebb763bb5cea4ec6803fd180d540ec5b07a9fcb2c118251d52c"
+checksum = "79b879fb8c20405663309986621856050efc31969c2d2a209d78373356a62e27"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6877,9 +6934,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-vesting"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4525f3038cdf078fea39d913c563ca626f09a615e7724f0c9eac97743c75ff44"
+checksum = "391edd70faa651c43c2bbd03fcb5cd3f0be8b45ed38231991fe46d33a4cc4ef5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6893,9 +6950,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-whitelist"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0ad4ce05688bdddcdb682cbed2f3edff0ee5349f0b745ebacc27d179582432"
+checksum = "92b496a76f13982cd754be92c9167d71acad169d101db197910e2a6e94f49997"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6909,9 +6966,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "8.0.4"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13f5c598737e84294880333170d1df3868a11ad7ee79d0b1d1af37365e1c277"
+checksum = "085a71440a945fae1bc6077fd40bdf1780a7e31747b86b2012bba18b18f0d6ef"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -6933,9 +6990,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "8.0.2"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c10e1c92086ce2069a3d2387d9431f48660b6ec92054c4d0a4e30a9f54e7ad3"
+checksum = "287ba50bd51c3c923fd35aa8e25f778092c7f3027d583389688bc003b24897c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7068,9 +7125,9 @@ dependencies = [
 
 [[package]]
 name = "parachains-common"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34aa00981a24a2b772afaa49e258f9bcd6bb372db060a05614becc1c74d4456"
+checksum = "4225b381c6f6f70e1d8e459207de9383270a781da1a581af1b9400955e7319e0"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -7391,9 +7448,9 @@ checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdfa52beecc446ccf733dede1a0089e6396d3df13401004d27c0ce2530816bc"
+checksum = "700317e8e7be1a4cad0dc3f626b7ce7382af553bf3f1752bc975a887035a39d1"
 dependencies = [
  "bitvec",
  "futures",
@@ -7412,9 +7469,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80ffc856dfbdb31178625760824ae320ddb7dd5694b217f489bd2832b8de15a5"
+checksum = "11b46382396d07d3d34f7676dd58c6eb6f9f94dd1b1aa48f89264bf132d11dd2"
 dependencies = [
  "always-assert",
  "futures",
@@ -7429,9 +7486,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-distribution"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d05c26cc8d6fa0f5f432d9de880f20ad0d24ca51a618834ea6612d1bd96ab1"
+checksum = "5baac9436b7bb35824af5153517d8f8309a9bd4c5805d6c0971dd0035c60d0ed"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7453,9 +7510,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-recovery"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d77e0b979f43861ab4c78c216c2729644bb12812f9bc859858bd3b8fc56b4d6"
+checksum = "273446475e356832b4bbb0df6bfa264d03368438f34038a676e60b99062ff4ff"
 dependencies = [
  "async-trait",
  "fatality",
@@ -7477,9 +7534,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef362c44280e3883a39ca452acc4a4fb61a18250d634d68578b22df7edd8290c"
+checksum = "f6bdf424d53f877dcfdeddb12542810e1475f496f9e48034b6870fb5921dd7e2"
 dependencies = [
  "cfg-if",
  "clap",
@@ -7499,6 +7556,7 @@ dependencies = [
  "sp-io",
  "sp-keyring",
  "sp-maybe-compressed-blob",
+ "sp-runtime",
  "substrate-build-script-utils",
  "thiserror",
  "try-runtime-cli",
@@ -7506,9 +7564,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507391f1be9f9b9a8fbf28ca13b0ab3f04947a54a1115d423d115aacf8889bf4"
+checksum = "559a7962f04ba8ebc1f149703cb50580265b4539b09d37cde71590863efaa0a8"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7529,9 +7587,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-core-primitives"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a08e4e014c853b252ecbbe3ccd67b2d33d78e46988d309b8cccf4ac06e25ef"
+checksum = "89a881f63ab7a652aba19300f95f9341ee245ad45a3f89cf02053ecace474769"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7542,9 +7600,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-dispute-distribution"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae32e83ef6bc0ec2874c76c19dff8f3795832ccc27f0abc587a7137994c42d26"
+checksum = "d07a449ae0d91325e9be1bbc6b17cb43554d6bf571f07185270785e8b26695d1"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7568,9 +7626,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b10514ace3272d38b602e1795a5a340b265285c4af875473d682a5c9d6c831c"
+checksum = "6f506b0ec86fcabb49bfd5b3ff80ae512d2a54fa2b0ff69edef10c565cd23db9"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -7583,9 +7641,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-gossip-support"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f05f7f60022d4beb30414f1f7c7e4ae728fea02086a4a0f8ff0a73e73ea4aa"
+checksum = "90f2c8cae6865a9e7b8f8b8b5521e3ed9d9d02ca54002a641d746e37be98e87d"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7606,9 +7664,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-network-bridge"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049ec1298ac6e96bcf4d980cd5864aceeee73b3298ab5d6dd7a3193d47578abc"
+checksum = "67319452213c24a5c565f3e9171e99bd7a56280e1fea8b67612ce8058ee619a3"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -7630,9 +7688,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-collation-generation"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f1211ab8b154c2e2b4b89c64f57f96056c881e4fcfa2ce29b6e5cbc978e74f1"
+checksum = "67f2683d1c65dd1e17b84ac32011fe6018faed0612cfa3ea71e64dc9cee52862"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -7649,9 +7707,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61a17b7e4edd3b73afbe0c6e8b5369bf3b721361a232baf11fb1698077067a4"
+checksum = "e8144a2c26eff4c0e1d162a450392dd4b2646c232f8cd8eaa4c75fd9764b69e4"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -7683,9 +7741,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-av-store"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b334f06423ff701e4b807d6832741ec24e0e97ebc13b560fc99bc0652926c0"
+checksum = "d1c442c0ee75b1b2f861414778c2b05ab0e6a673eb524652f012b9639653806b"
 dependencies = [
  "bitvec",
  "futures",
@@ -7706,9 +7764,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "8.0.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07f8840f3f2f0bee6264c18ce471c99c925f9afb65952e1d584b6d773cf4115"
+checksum = "3eeeda38afb82f8ea95f5860725a4ae1b060840ced6332dd7ca0b4b906f0b3b7"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7727,9 +7785,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0687006f843d6da8687eb24da735a04cbdcf4c3a98d82055b9b3a9047537e17e"
+checksum = "ce8d886e3b3fa9e3c3dbe3ca44df415ec41fe0b01686e48aa20a47120721304d"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -7743,9 +7801,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3035acf9069801e980b91b5178591f8a7052b4409de13824db7a6c798b36b98"
+checksum = "7eacb9a860d87ced5280f47fc2c023282047b4cabdd5e33865302782dd77cce5"
 dependencies = [
  "async-trait",
  "futures",
@@ -7765,9 +7823,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-api"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c990b9ffdde6725fe79f55e3b7c4c32ce2134a06103708476fa595a4ac652e95"
+checksum = "15faa14a59751ce1493f5389140b6c19751cc2f7e53b1f2261b1c8e71d1b2373"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -7780,9 +7838,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451965f3ace786d392c407872d61324765061b87027890b02ffd625554531f97"
+checksum = "e7ed635cd100270b52802f9c8486787514bd13565ec2f07cce40c0918c53635c"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7798,9 +7856,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13ea9d5b4aa43b5b1f718c3ec951adff0b0d74909cb1fe28206f5d88492247d"
+checksum = "3849f92ea7a2b52dc39ba7e8edcbaff01afcf9ed219765ec1d986a1380251601"
 dependencies = [
  "fatality",
  "futures",
@@ -7818,9 +7876,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6574c0bda4e10d722f761d4b8ab5d1708f0f963e5840370aa9cee8f559c90a23"
+checksum = "d68062a903ac7ec9bb5407e0510172797c2d3b62c1b28d59bb90c34d0710b488"
 dependencies = [
  "async-trait",
  "futures",
@@ -7836,9 +7894,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "160f80a11b9d2b8e36e510ea54ce5b06e77179c0c502f7e19e5a5809bc1523ee"
+checksum = "82a512f6bdf897ef113dca7db016c0cc029d230d7d4059c69df9462e13589f2c"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7854,9 +7912,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "8.0.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d0a64371700537c3dc15b3956536e4541f093b7c38ac21737ea9fea3562a83"
+checksum = "3e84786bfd62419354ecad7090b2e4106edef8d8e65b74823ab251f35133bb6f"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7872,9 +7930,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3bbb1b5f4b966f21a0336e94c0a0222958d2f3cba451da1157af271d07f9748"
+checksum = "c774546fb65783d59090c8be6a01ca87c4f2966f090eab9ad0e73fb12924bb5d"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.2",
@@ -7906,9 +7964,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ab4a91e62a9f7e67cf400931578f2505417cc43a32ac29458163604f2b277b"
+checksum = "6f125ffe763ce46419ed26ba3454244e3573e75936b52531bba0262ae99cc2d8"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -7923,9 +7981,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-common"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003981d3b63e4f527ef7f03cbe280e41ec649d9be365668887f0b107610640f4"
+checksum = "e75d55ed5b6b835a087fa97fc11f70fc388a23eecc2e02a40d922cd3a88f78f5"
 dependencies = [
  "cfg-if",
  "cpu-time",
@@ -7951,9 +8009,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-runtime-api"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6ea6a03f297b7387fc59c41c3c32285803971cb27e81d7e9ca696824d6773"
+checksum = "1d027fdd36799a4d14693817e8364bb9b7942efd6a8d21f64181f44d96edc6cb"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -7967,9 +8025,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-jaeger"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d113b48e7b6126964c3a790b101d99e17fd3cb75a92e94d54587ce1340df21"
+checksum = "a0bf1270f55774b17d7cf822b99cd932da86f2e960260b0532302e6aef391795"
 dependencies = [
  "lazy_static",
  "log",
@@ -7986,9 +8044,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef2e2a934f0d0d606fcfc53fc26f4cacd8b9f18fb2118829203fa813af2cdae"
+checksum = "5ebd5bc6a4e659504941f274fbc1cfb2e6e3108ff1994826c9b39fcf0254b010"
 dependencies = [
  "bs58 0.5.0",
  "futures",
@@ -8006,9 +8064,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f9e67b0f25d695947a15b6fe8ee6f8e83f3dfcbca124a13281c0edd0dc4703"
+checksum = "48d36d184c0a1edc1cb21cda372bd875257b0d3a1cf35f1d79f325ad7dba0811"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -8031,9 +8089,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375744eee7a53576387e14856e1c65be8ecef8b449567bb2cff85706266c8912"
+checksum = "30bbe56f395b6dc07eb2f7929c8ee98e20004b9d71c1af2122994626e0ec3549"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -8055,9 +8113,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d6c226cdbcd48ab1e506d8512f0fb01839f9a72eec2fc0cf7771f6d3352171"
+checksum = "ba2902ddd1af2c5cb9d9e5504efd39845cc75cc9184d3146c48081e83ed94767"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -8066,9 +8124,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1404525da0ab9d44bac1041449bf0c5576240f9031b305dc41654567e98b6021"
+checksum = "0f754c9e481ee0a50c234884ca5424cec1358fb044c37645a65b154c8fb8a8a8"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -8095,9 +8153,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a7d101f28bf718d15f01a060ed8cf7a7e2d8d5705c494b49ece696cada0adf"
+checksum = "98926d96c3a5ca4fec1e9ca28bef44204569244839f9252ca0df19e23a8142f7"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8131,9 +8189,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-overseer"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5ed988deffeddf440473586f62efc5dd498f6016e6650881db09dd60b3b24f"
+checksum = "35434f12f38e9fe1898ee9d0e46459b59c6613122f89fdc68ba677a6080fda8f"
 dependencies = [
  "async-trait",
  "futures",
@@ -8154,9 +8212,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-parachain-primitives"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248ab090959a92e61493277e33b7e85104280a4beb4cb0815137d3c8c50a07f4"
+checksum = "567c738aa6b8d7eb113fe73e50fb9b6292f818f54da98bb25c7fe73e98d1709a"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -8172,9 +8230,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-primitives"
-version = "8.0.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d5f9930210cab0233d81204415c9ef4a8889cdf3e60de1435250481a2773ca"
+checksum = "20a6d6b36fdda53a0c50c4c6fbbda8ff557c9cf5b0a9edaea1f9641756ec1981"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -8200,9 +8258,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-rpc"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4747cb8faa532e8446b38b74266fd626d6b660fe6b00776dd6c4543cc0457f"
+checksum = "b9c02431c0f9947cf931113d492512b99478b4aefe2a3a2e49b59e45219f5d6f"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -8234,9 +8292,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "8.0.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06afbb3bd10245ad1907242a98ddffc3c0c1e209738b8382bc5bcfc1f28c0429"
+checksum = "647ece8082c13a03f19c6e0c1c486891c02169be2e0f9898afe5db607fc6aa7a"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8286,9 +8344,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-metrics"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3566c6fd0c21b5dd555309427c984cf506f875ee90f710acea295b478fecbe0"
+checksum = "3881206c09c9aafc5a8a801013d4069f012a0a68eb7edf5f1ac423196f76481e"
 dependencies = [
  "bs58 0.5.0",
  "frame-benchmarking",
@@ -8300,9 +8358,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "8.0.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bcfd672be236fd1c38c702e7e99fe3f3e54df0ddb8127e542423221d1f50669"
+checksum = "5003965d03a5b6c8b98350f8f10f42a6ce04875a048a98e4c1523e42cf3f72b4"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -8350,9 +8408,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-service"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2fd665185877bec296588c7cf1ec0ef75e0545050b5e1d42d94240a284149da"
+checksum = "9709302c0e87754ec1eb90ac817978f737fb68b5f1184308a818a3602fe390e6"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -8468,9 +8526,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff6d16cbd994987f48a9f107f12e4c7fff26cdd71df6288e9521adc7cff3427"
+checksum = "7e58f5c1ec49dabd807c0bd5c77c53774d9c094652d4c198a832e7ddc754c945"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -8492,14 +8550,66 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-table"
-version = "8.0.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5e010da3c6a65d8f263d0f825a04d995ffc8a37f886f674fcbbc73bf158d01"
+checksum = "b2fb894021b1318d752d29b1b65721833aa668876e1a780ac760c59d40f5d759"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-core",
  "tracing-gum",
+]
+
+[[package]]
+name = "polkavm-common"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92c99f7eee94e7be43ba37eef65ad0ee8cbaf89b7c00001c3f6d2be985cb1817"
+
+[[package]]
+name = "polkavm-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79fa916f7962348bd1bb1a65a83401675e6fc86c51a0fdbcf92a3108e58e6125"
+dependencies = [
+ "polkavm-derive-impl-macro",
+]
+
+[[package]]
+name = "polkavm-derive-impl"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c10b2654a8a10a83c260bfb93e97b262cf0017494ab94a65d389e0eda6de6c9c"
+dependencies = [
+ "polkavm-common",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "polkavm-derive-impl-macro"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e85319a0d5129dc9f021c62607e0804f5fb777a05cdda44d750ac0732def66"
+dependencies = [
+ "polkavm-derive-impl",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "polkavm-linker"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdec1451cb18261d5d01de82acc15305e417fb59588cdcb3127d3dcc9672b925"
+dependencies = [
+ "gimli 0.28.1",
+ "hashbrown 0.14.3",
+ "log",
+ "object 0.32.2",
+ "polkavm-common",
+ "regalloc2 0.9.3",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -8858,6 +8968,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca0b7bac0b97248c40bb77288fc52029cf1459c0461ea1b05ee32ccf011de2c"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8998,6 +9123,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
+dependencies = [
+ "bitflags 2.4.2",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9104,6 +9238,19 @@ checksum = "80535183cae11b149d618fbd3c37e38d7cda589d82d7769e196ca9a9042d7621"
 dependencies = [
  "fxhash",
  "log",
+ "slice-group-by",
+ "smallvec",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
+dependencies = [
+ "hashbrown 0.13.2",
+ "log",
+ "rustc-hash",
  "slice-group-by",
  "smallvec",
 ]
@@ -9223,9 +9370,9 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d089e93be2b8b76dd0d4b794a6a995ca3a1d6cb0ea3dd1cd42462f048bcfc926"
+checksum = "24202c576ef8aec7a65e0662e031936a1311a8cef51caffaae2cb3fd0c97f7fe"
 dependencies = [
  "binary-merkle-tree",
  "frame-benchmarking",
@@ -9320,9 +9467,9 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b45c21ccb0f8777512a65510c106aeee4b59682944b9a5cb31cd7b8ed4ccb47"
+checksum = "74f036bf3c4f8cc01301dbe91e601e736e1939f42ef7a364058f26752305527e"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -9474,8 +9621,22 @@ checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring 0.17.8",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle 2.5.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -9485,7 +9646,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.1",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -9500,12 +9674,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
+dependencies = [
+ "base64 0.21.7",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "868e20fada228fefaf6b652e00cc73623d54f8171e7352c18bb281571f2d92da"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -9563,9 +9764,9 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
-version = "24.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357127c91373ed6d1ae582f6e3300ab5b13bcde43bbf270a891f44194ef48b70"
+checksum = "97e78cc21b2bb1d13b33d9c64fbb02a10efde428e8f0a68a0ca2084203123933"
 dependencies = [
  "log",
  "sp-core",
@@ -9575,9 +9776,9 @@ dependencies = [
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb3c14cb8022844835a6f7209196b8c6544d389fe5d2972d8df2ae4ca75afbe"
+checksum = "d0f294602dc9f593e8aae35288f02d16f87ff49f96b8e6d442cb9f1d3aa6967e"
 dependencies = [
  "async-trait",
  "futures",
@@ -9605,9 +9806,9 @@ dependencies = [
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724c3a6eee5f0829a1b79a15e12d63ed81b33281b14004a6331a8883b2fd8fd1"
+checksum = "cede898c7079b789b42c4fdd8f1ff74f7007232406cd0299e2c3a5ada1db2910"
 dependencies = [
  "futures",
  "futures-timer",
@@ -9628,9 +9829,9 @@ dependencies = [
 
 [[package]]
 name = "sc-block-builder"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8b0640994965c6ff3afa13242d95a61611b83da21fd86ac2b1ebd03e241a02"
+checksum = "eb2a2f425079daf382b0f1cf3b9085bed25db13ec8ad0ff64b0dc75ff457c0f7"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9644,9 +9845,9 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f73880050f8b04fed7f6301279ef3899df13a3891bd06156d56f9a1c50fefba"
+checksum = "41472507ca721651ef117a2702a9bd6d9d9e8ce5f16840a71741993319926191"
 dependencies = [
  "array-bytes 6.2.2",
  "docify",
@@ -9683,9 +9884,9 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a284c10ea92b1fe789b9f0e5815d393f3a1e3bf6a4adaa884f24e36143b83b"
+checksum = "274117ab32d7b3b2f790c841b61f22027d80f344c00b8ce38df772553a8a5409"
 dependencies = [
  "array-bytes 6.2.2",
  "bip39",
@@ -9725,9 +9926,9 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e914dfadaaf384d8869ae47f3ec783bf6a1ac24e7827f5fec2e0e649a450a91"
+checksum = "7acaa6df639ac7a7f10060daf50461afddf6635ea148514a1eceba3384046c30"
 dependencies = [
  "fnv",
  "futures",
@@ -9753,9 +9954,9 @@ dependencies = [
 
 [[package]]
 name = "sc-client-db"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f08c4f29e6d2b8915bab6435b8817fa39ef7708c04a7cf6226f803e133b017c"
+checksum = "d946e00b4bef179ef7c2d29966935d96e38176a543249c1b17fdeacfc3446bb4"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -9780,9 +9981,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e1ac2c698b828073982b6f5b1a466fcc345a452983356af74254ade8e9987d"
+checksum = "081b1b7bd2894e4614acbfa47424771a5102bf907b31d2bbd379e8c4f3b55b09"
 dependencies = [
  "async-trait",
  "futures",
@@ -9806,9 +10007,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a16fd09794291795ad43ea1df7190083f9a47fc0a73e9b8ec0ae98fbe53a2b34"
+checksum = "5ca4c0040ba696f6eac9a6b627dbb487b27076203c5ed1b03fac6c993df5b627"
 dependencies = [
  "async-trait",
  "futures",
@@ -9836,9 +10037,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ec3dc31f8fd024684d1306488836680558b680a8ec38219e19f20854811f02"
+checksum = "34c140923b84be4b0cd089755aeed53e4da9008d364f61e3c9d46f263112582d"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -9873,9 +10074,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf2b3004672f9eea0d9af6c9b944fa3ef0bc72fd88cea9075cdf6dc96d1439ac"
+checksum = "83ad369cae7dbeb4da4007dc8b1b27b905bf027172bbbf6dbede15e2539f0b2b"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9896,9 +10097,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ce3ee15eff7fa642791966d427f185184df3c7f4e58893705f3e7781da8ef5"
+checksum = "7db11fe9923a5c11e9d2a65e32b324cb970fa2abf1b59f7e7844f89be77c1b28"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -9933,9 +10134,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy-rpc"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1ed5e8ac2cb53c6a248c8f469353f55bd23c72f23fe371ac19c1d46618de1a"
+checksum = "36862ae5859008621ae53fcf6f8e5a960637aedf4de6995344672ba2619053ce"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9953,9 +10154,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f68ddb91626f901578515eed93c7919f739660161f4e9f7b9407e2d0ede981"
+checksum = "fe1b2a3983e135b897079cbe20a6998fc83bfdffc9e803cb2a7e5326af30d60c"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -9967,9 +10168,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-grandpa"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae91e5b5a120be4d13a59eaf94fd85d7c7af528482b8e21d861fa1167df3083"
+checksum = "86ea4771511dfcabe0e0dd3a43368ba3f430b0aaf736463b14286cc10a6494e6"
 dependencies = [
  "ahash 0.8.11",
  "array-bytes 6.2.2",
@@ -10011,9 +10212,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-grandpa-rpc"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697cbd528516561dbc818a8990d5477169e86d9335a0b29207cf6f6a90269e7c"
+checksum = "df4f1fb2262e1f96c66664da4b7045069013ffcaefbf44730913d5ac74f77c2f"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -10032,9 +10233,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567bddd65d52951fb9bc7a7e05d1dfdfc47ff2c594ec5ca9756d27e7226635bb"
+checksum = "7ddad1b613fa5118016c11f1015ba5ff9a9f2ce914a72482ec0303d4d828e2f9"
 dependencies = [
  "async-trait",
  "futures",
@@ -10056,9 +10257,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2ac6c356538d67987bbb867e11a12a84ba87250c70fd50005b6d74f570a4f7"
+checksum = "a331ae16b0a17ed474eaf9c2dc01b145511cf4bd62ffc165d7dd1d3f13e48a94"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -10079,9 +10280,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-common"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07498138dee3ddf2c71299ca372d8449880bb3a8a8a299a483094e9c26b0823e"
+checksum = "a3f414028dc468aafd449cb659f7664e39540f3308945ec9cf2209c1359fa67e"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -10092,9 +10293,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmtime"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a387779ab54ec1ffce0bf3a6631faada079459d42796c1895683767918a642"
+checksum = "4dcacfc88265486c337ef97a042ba42ccd1903520dbff40116dbe837e3ee6b89"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -10111,9 +10312,9 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb603a0a703f1bc10a4e6462bec1036d8fb8b3e3eff5513a9c07f98ccb8d662d"
+checksum = "ea5d24b1f02efd53092a78be46b7e6fc4805b3fb723bbcc8928574d9fa309a94"
 dependencies = [
  "ansi_term",
  "futures",
@@ -10129,9 +10330,9 @@ dependencies = [
 
 [[package]]
 name = "sc-keystore"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc4f6a558dd23e3bae2e9f195da822465258b9aaf211c34360d7f6efb944e54"
+checksum = "0413f82a27eded5a12e1f3d02c478b378e72912fbdf3b8b9cae7c5995c5a8f89"
 dependencies = [
  "array-bytes 6.2.2",
  "parking_lot 0.12.1",
@@ -10144,9 +10345,9 @@ dependencies = [
 
 [[package]]
 name = "sc-mixnet"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45fb213c15679fe5b87c383815d7fb758c70d3e7c573948bd7fe26ff344d2272"
+checksum = "f9aaa5a9d17d0ea54a5da0af04f0c187f65500d7597395eaae313c511a08db6c"
 dependencies = [
  "array-bytes 4.2.0",
  "arrayvec 0.7.4",
@@ -10174,9 +10375,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f231c7d5e749ec428b4cfa669d759ae76cd3da4f50d7352a2d711acdc7532891"
+checksum = "bf955c8966573e7e3cc940e831d792945a41d6e443766ad50e50a5af75e1ef74"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -10218,9 +10419,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-bitswap"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f89b0134738cb3d982b6e625ca93ae8dbe83ce2a06e4b6a396e4df09ed3499"
+checksum = "b5b34047c641db262b9035ef809b1184e55b3f6c45bf3f6110f293d3652ec663"
 dependencies = [
  "async-channel 1.9.0",
  "cid",
@@ -10239,9 +10440,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3504bbff5ab016948dbab0f21a8be26324810b76eff3627ce744adb5bfc1b3ce"
+checksum = "ec7cfe68e017be02fd9911cd1e4db50bae31671e01e988ef5c375d0092ff7c71"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -10257,9 +10458,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad02cf809c34b53614fa61377e3289064edf6c78eb11df071d11fbf7546d7e9"
+checksum = "0a6c4ffd60fe240d9b0963ec60752810660a201755a77b922aa5e8ef7256f6b5"
 dependencies = [
  "ahash 0.8.11",
  "futures",
@@ -10277,9 +10478,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-light"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84ef0b212c775f58e0304ec09166089f6b09afddf559b7c2b5702933b3be4"
+checksum = "01f3ca1b7e567ca60535bb76b3f8617e8d40de0067f7d1794d3f5ef7ed7a4d0e"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -10299,9 +10500,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-sync"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa9377059deece4e7d419d9ec456f657268c0c603e1cf98df4a920f6da83461"
+checksum = "50a16e2817ef6def510a89b2e439b13f53b31d783344061b8551a37b6fb61ef4"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -10336,9 +10537,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c9cad4baf348725bd82eadcd1747fc112ec49c76b863755ce79c588fa73fe4"
+checksum = "658a81c4a24f874ada1cac70db349ff7983956563e39e1468eb6e8703f07057e"
 dependencies = [
  "array-bytes 6.2.2",
  "futures",
@@ -10356,9 +10557,9 @@ dependencies = [
 
 [[package]]
 name = "sc-offchain"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aee89f2abd406356bfd688bd7a51155dc963259e4b752bb85d1f8a061a194fd"
+checksum = "d099f8d2f399be5b7d163e4236faaa47e7ce131f4021b9fe8e3e607e0ca51364"
 dependencies = [
  "array-bytes 6.2.2",
  "bytes",
@@ -10401,9 +10602,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5acf6d89f062d1334a0c5b67e9dea97666cd47a49acb2696eab55ff1a1bf74"
+checksum = "61faa018966cb794e36be31af4ed4d19deaa93c751ff32512637c7bca104e9e8"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10434,9 +10635,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9db6aaabfa7e0c27ec15d0f0a11b994cd4bcf86e362f0d9732b4a414d793f0f"
+checksum = "f716a273af4f4782430ebe4fe6d0f8b1490ff7c103dc78193706bfff370c250f"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10455,13 +10656,17 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-server"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691440bbaddd3bc2675309c965cc75f8bf694f51e0a28039bfc9658299fbc394"
+checksum = "42ae724afa9862381f77b6d3a205baef5daceec9e584f17069546eb7dfca5400"
 dependencies = [
+ "futures",
+ "governor",
  "http",
+ "hyper",
  "jsonrpsee",
  "log",
+ "pin-project",
  "serde_json",
  "substrate-prometheus-endpoint",
  "tokio",
@@ -10471,9 +10676,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-spec-v2"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f10275c62296a785f6e2ac716521e3b6e0fae470416fdf86491cbbfcc2e23d"
+checksum = "8599ca0b78580328cafa11fdb2d89d8678ba64e937c957515816492e87066bad"
 dependencies = [
  "array-bytes 6.2.2",
  "futures",
@@ -10483,6 +10688,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
+ "rand",
  "sc-chain-spec",
  "sc-client-api",
  "sc-rpc",
@@ -10502,9 +10708,9 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ea779b8c5bdb0d0199c8beebcf1fdc5641e468c480e1c4684be660c8c90af"
+checksum = "32ea0efa7cf58f6cacb04034939e62f12ce7bf2df6a60f67e2d5c2f27fe54999"
 dependencies = [
  "async-trait",
  "directories",
@@ -10566,9 +10772,9 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa842052c41ad379eaecdfddc0d5c953d57e311ae688233f68f461b91d38da0a"
+checksum = "748f92aa2827647932a04685df8e00b9763d4060635ca84eaeb3788822198013"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10578,9 +10784,9 @@ dependencies = [
 
 [[package]]
 name = "sc-storage-monitor"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26cb401aad6732700c8d866cbbef1175b9aeb8230908aff27059ef14bd058ef3"
+checksum = "5d112a704c9dc76c78c3f17d5912c4ee17fce6d4b1c7cac55ca4acd78a8985c5"
 dependencies = [
  "clap",
  "fs4",
@@ -10592,9 +10798,9 @@ dependencies = [
 
 [[package]]
 name = "sc-sync-state-rpc"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc382c7d997f4531eee5e5d57f970eaf2761d722298d7747385a4ad69fa6b12"
+checksum = "9e2a59d517a60a3fdc0b12e7a1f112a2affbc9caf4f93b53d44c5e0edb485945"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10612,9 +10818,9 @@ dependencies = [
 
 [[package]]
 name = "sc-sysinfo"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d2ab8f15021916a07cfbe7a08be484c5dc7d57f07bc0e2aa03260b55a5632f"
+checksum = "399e72ba964c0394181db8680c34b3503116c217b0fe3564696857ea9ca4aa68"
 dependencies = [
  "derive_more",
  "futures",
@@ -10634,9 +10840,9 @@ dependencies = [
 
 [[package]]
 name = "sc-telemetry"
-version = "16.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0673a93aa0684b606abfc5fce6c882ada7bb5fad8a2ddc66a09a42bcc9664d91"
+checksum = "6c6807ebd9f43ab628931842d3aaa9404ddfd07013e9c7027ca603f496939577"
 dependencies = [
  "chrono",
  "futures",
@@ -10654,9 +10860,9 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77b4fdb4f359f19c395ba862430f3ca0efb50b0310b09753caaa06997edd606"
+checksum = "e7abee1c60e6f55a09ae0b9055093709bc84ff2bb55a3828167d556f724f82cc"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -10697,9 +10903,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "326dc8ea417c53b6787bd1bb27431d44768504451f5ce4efdde0c15877c7c121"
+checksum = "cfe004c916f4be7eebf52f05df1d44a240b653cb42c7a6c49692553620b46d5f"
 dependencies = [
  "async-trait",
  "futures",
@@ -10725,9 +10931,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ae888ce3491acb1b489c3dba930d0c46c7ef9f9893ba0ab8af9125362f3d14"
+checksum = "7fe0eeb21d4f09a9edffee481df544bb6fc83cccc0788c19ceebd760f1afd167"
 dependencies = [
  "async-trait",
  "futures",
@@ -10742,9 +10948,9 @@ dependencies = [
 
 [[package]]
 name = "sc-utils"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b1a238f5baa56405db4e440e2d2f697583736fa2e2f1aac345c438a42975f1"
+checksum = "1863d482be044f4768ef5de6119dc70b5e31e6e9f71ad225c177474d6540e424"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -11139,9 +11345,9 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "slot-range-helper"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40fa5e14772407fd2ccffdd5971bf055bbf46a40727c0ea96d2bb6563d17e1c"
+checksum = "6a140c7f8a757329f7448053a512e937f8cb3def1ea37a25991625a8a592d4ef"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -11334,9 +11540,9 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef42aa652381ade883c14ffbbb5c0fec36d382d2217b5bace01b8a0e8634778"
+checksum = "298331cb47a948244f6fb4921b5cbeece267d72139fb90760993b6ec37b2212c"
 dependencies = [
  "hash-db",
  "log",
@@ -11347,6 +11553,7 @@ dependencies = [
  "sp-externalities",
  "sp-metadata-ir",
  "sp-runtime",
+ "sp-runtime-interface",
  "sp-state-machine",
  "sp-std",
  "sp-trie",
@@ -11356,9 +11563,9 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0694be2891593450916d6b53a274d234bccbc86bcbada36ba23fc356989070c7"
+checksum = "18cfbb3ae0216e842dfb805ea8e896e85b07a7c34d432a6c7b7d770924431ed2"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -11371,9 +11578,9 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547cad7a6eabb52c639ec117b3db9c6b43cf1b29a9393b18feb19e101a91833f"
+checksum = "0b4b7b12922cb90cf8dff0cab14087ba0ca25c1f04ba060c7294ce42c78d89ab"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11385,9 +11592,9 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "24.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa823ca5adc490d47dccb41d69ad482bc57a317bd341de275868378f48f131c"
+checksum = "910c07fa263b20bf7271fdd4adcb5d3217dfdac14270592e0780223542e7e114"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -11400,9 +11607,9 @@ dependencies = [
 
 [[package]]
 name = "sp-authority-discovery"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92b177c72b5d2973c36d60f6ef942d791d9fd91eae8b08c71882e4118d4fbfc"
+checksum = "0addabbce9f90c614145067139122420cfc940c495d2c3c1acc4a3b5f392f914"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11414,9 +11621,9 @@ dependencies = [
 
 [[package]]
 name = "sp-block-builder"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b36ce171caa7eb2bbe682c089f755fdefa71d3702e4fb1ba30d10146aef99d5"
+checksum = "1b35d0992e2183686215dccb4bcb5003b4eb52feec82d82dabd81db7401d845a"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -11426,9 +11633,9 @@ dependencies = [
 
 [[package]]
 name = "sp-blockchain"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31303e766d2e53812641bbc1f1cec03a85793fc9e627e55f0a6854b28708758"
+checksum = "c24a17e8e5406725ab805ee5cbab4b2a9181b7b8dd93f9c302eed76216c6321a"
 dependencies = [
  "futures",
  "log",
@@ -11445,9 +11652,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6e512b862c4ff7a26cdcd364898cc42e181ff5cb35fbb226ff27d88c81569a"
+checksum = "6e3841d5b5929080c92ef846db7e1a8323d6352b981a6b5cbccd0886fdf1a85e"
 dependencies = [
  "async-trait",
  "futures",
@@ -11461,9 +11668,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf13c293685319751f72fa5216c7fb5f25f3e8e8fe29b4503296ed5f5466b3d"
+checksum = "14dc8e041fcb128e9e6a0d706c243b7263dae7d45098a9450498a1657abac2f3"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11479,9 +11686,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9be2f86a2f0ce2a78b455feb547aa27604fd76a7f7a691995cbad44e0b1b9dd"
+checksum = "473409ca152309b11898dd53130a578b341bc285ca9410246cbf1acc02996126"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11499,9 +11706,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-beefy"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ff890a84ef57628b010df0e1d75b3a78fb7f575e4ceeba7215c276902c403e"
+checksum = "35714055bde4332baf54bad9ab324d9d205efe91f96b2af4171c6105ff68d7ea"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -11512,6 +11719,7 @@ dependencies = [
  "sp-core",
  "sp-crypto-hashing",
  "sp-io",
+ "sp-keystore",
  "sp-mmr-primitives",
  "sp-runtime",
  "sp-std",
@@ -11520,9 +11728,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-grandpa"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b606164600db36e596db7abf32b4533dc9a74526d9444c4c45035427b2199b"
+checksum = "a47109ea7b003030bc7cff2724e785859b9b8e6504866ffa1a3b55380cb11d53"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -11539,9 +11747,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73a5bd1fcd84bbdc7255528c7cdb92f9357fd555f06ee553af7e340cbdab517c"
+checksum = "1c72408adadb54b6f4eb287729166528cdb83e08c796685edc9bee09571b6474"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11552,9 +11760,9 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c33c7a1568175250628567d50c4e1c54a6ac5bc1190413b9be29a9e810cbe73"
+checksum = "586e0d5185e4545f465fc9a04fb9c4572d3e294137312496db2b67b0bb579e1f"
 dependencies = [
  "array-bytes 6.2.2",
  "bip39",
@@ -11644,9 +11852,9 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7096ed024cec397804864898b093b51e14c7299f1d00c67dd5800330e02bb82"
+checksum = "a1d6a4572eadd4a63cff92509a210bf425501a0c5e76574b30a366ac77653787"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -11656,9 +11864,9 @@ dependencies = [
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd865540ec19479c7349b584ccd78cc34c3f3a628a2a69dbb6365ceec36295ee"
+checksum = "a862db099e8a799417b63ea79c90079811cdf68fcf3013d81cdceeddcec8f142"
 dependencies = [
  "serde_json",
  "sp-api",
@@ -11668,9 +11876,9 @@ dependencies = [
 
 [[package]]
 name = "sp-inherents"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "607c9e35e96966645ff180a9e9f976433b96e905d0a91d8d5315e605a21f4bc0"
+checksum = "42eb3c88572c7c80e7ecb6365601a490350b09d11000fcc7839efd304e172177"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -11683,9 +11891,9 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec43aa073eab35fcb920d7592474d5427ea3be2bf938706a3ad955d7ba54fd8d"
+checksum = "0ca29e042628cb94cbcaefa935e624a9b48f9230dbce6324908e9b4f768317ef"
 dependencies = [
  "bytes",
  "ed25519-dalek",
@@ -11709,9 +11917,9 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cf0a2f881958466fc92bc9b39bbc2c0d815ded4a21f8f953372b0ac2e11b02"
+checksum = "7f9c74648e593b45309dfddf34f4edfd0a91816d1d97dd5e0bd93c46e7cdb0d6"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -11720,15 +11928,14 @@ dependencies = [
 
 [[package]]
 name = "sp-keystore"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444f2d53968b1ce5e908882710ff1f3873fcf3e95f59d57432daf685bbacb959"
+checksum = "bd4bf9e5fa486416c92c2bb497b7ce2c43eac80cbdc407ffe2d34b365694ac29"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sp-core",
  "sp-externalities",
- "thiserror",
 ]
 
 [[package]]
@@ -11755,9 +11962,9 @@ dependencies = [
 
 [[package]]
 name = "sp-mixnet"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bebd44b915c65aeb7e7eeaea466aba3b27cdd915c83ea83d4643c54f21ffbbf"
+checksum = "15a8078f19b1292220b7110115b49f4fcd427324f3b184f6d8dbeb6b4dd40d4d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11768,9 +11975,9 @@ dependencies = [
 
 [[package]]
 name = "sp-mmr-primitives"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891b7263b7c44a569173ee1078f68fb1a01991a44914607c0100aa5ae41f6562"
+checksum = "813e0a7e40c9a993d58baff7c6e742901a93fd63cc2ed9f253ed8c1b39fe9343"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -11787,9 +11994,9 @@ dependencies = [
 
 [[package]]
 name = "sp-npos-elections"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195d7e1154c91cce5c3abc8c778689c3e5799da6411328dd32ac7a974c68e526"
+checksum = "1bc47d1b765ddd3d73678edd25eed4c33193e67929060d729bd751790026077b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11802,9 +12009,9 @@ dependencies = [
 
 [[package]]
 name = "sp-offchain"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d83b955dce0b6d143bec3f60571311168f362b1c16cf044da7037a407b66c19"
+checksum = "f826efe7bdd6d142ced34f5ef1ed9a2070887e78d3146220250edeb67e6791d5"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -11824,9 +12031,9 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af4b73fe7ddd88b1641cca90048c4e525e721763199e6fd29c4f590884f4d16"
+checksum = "ffa9924fc1d0e7b79550493b8b8ac3fa58593cbdb169ee6cf6c1ee3ef25882dd"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -11835,9 +12042,9 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a95e71603a6281e91b0f1fd3d68057644be16d75a4602013187b8137db8abee"
+checksum = "b28fcf8f53d917e420e783dd27d06fd276f55160301c5bc977cc5898c4130f6f"
 dependencies = [
  "docify",
  "either",
@@ -11860,13 +12067,14 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "25.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2321ab29d4bcc31f1ba1b4f076a81fb2a666465231e5c981c72320d74dbe63"
+checksum = "e48a675ea4858333d4d755899ed5ed780174aa34fec15953428d516af5452295"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
+ "polkavm-derive",
  "primitive-types",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
@@ -11879,9 +12087,9 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfaf6e85b2ec12a4b99cd6d8d57d083e30c94b7f1b0d8f93547121495aae6f0c"
+checksum = "0195f32c628fee3ce1dfbbf2e7e52a30ea85f3589da9fe62a8b816d70fc06294"
 dependencies = [
  "Inflector",
  "expander 2.1.0",
@@ -11893,9 +12101,9 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b86531090cc04d2ab3535df07146258e2fb3ab6257b0a77ef14aa08282c3d4a"
+checksum = "0399eb885209b51b2999fe35883a579b0848674f0679019ce262f19d0a853325"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11909,9 +12117,9 @@ dependencies = [
 
 [[package]]
 name = "sp-staking"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e14d003ecf0b610bf1305a92bdab875289b39d514c073f30e75e78c2763a788"
+checksum = "48b92f4f66b40cbf7cf00d7808d8eec16e25cb420a29ec4060a74c0e9f7c2938"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -11924,9 +12132,9 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a67297e702aa32027d7766803f362a420d6d3ec9e2f84961f3c64e2e52b5aaf9"
+checksum = "23ae47765916d342b53d07be012a71efc4c1377d875ade31340cc4fb784b9921"
 dependencies = [
  "hash-db",
  "log",
@@ -11946,9 +12154,9 @@ dependencies = [
 
 [[package]]
 name = "sp-statement-store"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309a9ae4e8134bbed8ffc510cf4d461a4a651f9250b556de782cedd876abe1ff"
+checksum = "b95ede4523fc978585383465a406289235a71dd6febe7f79e1114794afae5cd0"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek 4.1.2",
@@ -11992,9 +12200,9 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249cd06624f2edb53b25af528ab216a508dc9d0870e158b43caac3a97e86699f"
+checksum = "ee9532c2e4c8fcd7753cb4c741daeb8d9e3ac7cbc15a84c78d4c96492ed20eba"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12019,9 +12227,9 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-pool"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9742861c5330bdcb42856a6eed3d3745b58ee1c92ca4c9260032ff4e6c387165"
+checksum = "a8e8b3208d1c8347ab75b28192dc7354489369ae652f2d9936521c8ccd92ca06"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -12029,9 +12237,9 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-storage-proof"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece8e22a5419c7a336a2544654e1389fec8cac19b93081a30912842b44e8167f"
+checksum = "4fa2b7cfb16da80934eab7e37c317969f0a19f31396c530279ce1110b3ecbd95"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12045,9 +12253,9 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed48dfd05081e8b36741b10ce4eb686c135a2952227a11fe71caec89890ddbb"
+checksum = "5791e2e310cf88abedbd5f60ff3d9c9a09d95b182b4a7510f3648a2170ace593"
 dependencies = [
  "ahash 0.8.11",
  "hash-db",
@@ -12070,9 +12278,9 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4a660c68995663d6778df324f4e2b4efc48d55a8e9c92c22a5fb7dae7899cd"
+checksum = "973478ac076be7cb8e0a7968ee43cd7c46fb26e323d36020a9f3bb229e033cd2"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12114,9 +12322,9 @@ dependencies = [
 
 [[package]]
 name = "sp-weights"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3be30aec904994451dcacf841a9168cfbbaf817de6b24b6a1c1418cbf1af2fe"
+checksum = "ab8a9c7a1b64fa7dba38622ad1de26f0b2e595727c0e42c7b109ecb8e7120688"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -12152,6 +12360,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12184,9 +12401,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-parachain-info"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7dc139d104f676a18c13380a09c3f72d59450a7471116387cbf8cb5f845a0e"
+checksum = "1ea840dfaa900fe1d6fef60bdfb446b1a03101a1c2620f50c7d43443b93df207"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -12199,9 +12416,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "8.0.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fa328b87de3466bc38cc9a07244c42c647b7755b81115e1dfeb47cc13fc6e6"
+checksum = "3028e3a4ee8493767ee66266571f5cf1fc3edc546bba650b2040c5418b318340"
 dependencies = [
  "array-bytes 6.2.2",
  "bounded-collections",
@@ -12218,9 +12435,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "8.0.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f6cfc27c1d45f9a67e20ed3f7e60296299688825350291606add10bf3bbff2"
+checksum = "6ea27e235bcca331e5ba693fd224fcc16c17b53f53fca875c8dc54b733dba3c6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12241,9 +12458,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "8.0.1"
+version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a638f4c8735cc04b5c93920a1f59e679f48b131315a07d146798e0decebf7720"
+checksum = "fe8c62fe1eee71592828a513693106ff301cdafd5ac5bd52e06d9315fd4f4f7a"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -12376,9 +12593,9 @@ checksum = "b285e7d183a32732fdc119f3d81b7915790191fad602b7c709ef247073c77a2e"
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f903d2f34703204f0003136c9abbc569d691028279996a1daf8f248a7369f"
+checksum = "74fba95234990a0eecb3199ee2589112a1a3763db1fa7739a316f3e26f7693c9"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -12409,9 +12626,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-rpc-client"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e5235d8460ec81e9a382345aa80d75e2943f224a332559847344bb62fa13b3"
+checksum = "0aa04291d8b0e96b475c2abc26fe96f59478e23af38307c294a6f6c3d2a06fc8"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -12423,9 +12640,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-state-trie-migration-rpc"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5768a5d3c76eebfdf94c23a3fde6c832243a043d60561e5ac1a2b475b9ad09f3"
+checksum = "a62395e13acaff44193068733ca986dd5b5be54055cabcee9cdad075b3a5f496"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -12441,15 +12658,16 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511bbc2df035f5fe2556d855369a1bbb45df620360391a1f6e3fa1a1d64af79a"
+checksum = "d182ae093d473b5947e32c392b10fb12125318c4470ff8adf32b0cbf2e9e6611"
 dependencies = [
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
  "parity-wasm",
+ "polkavm-linker",
  "sp-maybe-compressed-blob",
  "strum 0.24.1",
  "tempfile",
@@ -12786,6 +13004,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.2",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12978,9 +13207,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9690af7fe11d125786fa1b5ca802192f631b61a4411277865c8e0581c887e286"
+checksum = "ae8140321b63c471a47f6a5bcb46198a0a44535cd2afb26be624a9898d362422"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -13121,9 +13350,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "try-runtime-cli"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9454e1af0a0be675f837d63080ef8f43510c05df8c059570622386a0cf40b548"
+checksum = "0a6fda4ce30fe4bb6b3066b30669ebfabecaa8c974cc0411525256e465863347"
 dependencies = [
  "async-trait",
  "clap",
@@ -13782,9 +14011,9 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2a5cebb4c678a0d1291bb21f9d44ddebceae044b0fb5200fa3bed108a31595"
+checksum = "b6b66d94f5a1e81c045ead285988614cdf1869e1c6292e4f1b4b0a4a3c534074"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -13889,9 +14118,9 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime-constants"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b080c193714605ce1033311d85035247adca170181cd68a3ad7e3ca87755a14"
+checksum = "4143f3b5d631cb2bc1e0c4a4284dca4861ba0fcc62bfe861e505ff43fa1aa3dc"
 dependencies = [
  "frame-support",
  "polkadot-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,103 +20,103 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 hex-literal = "0.4.1"
 log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-smallvec = "1.11.0"
-serde = "1.0.195"
-clap = { version = "4.4.18", features = ["derive"] }
-jsonrpsee = { version = "0.20.3", features = ["server"] }
-futures = "0.3.28"
-serde_json = "1.0.111"
+smallvec = "1.11.2"
+serde = "1.0.197"
+clap = { version = "4.5.1", features = ["derive"] }
+jsonrpsee = { version = "0.22", features = ["server"] }
+futures = "0.3.30"
+serde_json = "1.0.114"
 
 
 # Build
-substrate-wasm-builder = "18.0.0"
+substrate-wasm-builder = "19.0.0"
 substrate-build-script-utils = "11.0.0"
 
 # Local
 parachain-template-runtime = { path = "./runtime" }
 
 # Substrate
-sc-basic-authorship = "0.35.0"
-sc-chain-spec = "28.0.0"
-sc-cli = "0.37.0"
-sc-client-api = "29.0.0"
-sc-offchain = "30.0.0"
-sc-consensus = "0.34.0"
-sc-executor = "0.33.0"
-sc-network = "0.35.0"
-sc-network-sync = "0.34.0"
-sc-rpc = "30.0.0"
-sc-service = "0.36.0"
-sc-sysinfo = "28.0.0"
-sc-telemetry = "16.0.0"
-sc-tracing = "29.0.0"
-sc-transaction-pool = "29.0.0"
-sc-transaction-pool-api = "29.0.0"
-frame-benchmarking = { version = "29.0.0", default-features = false }
-frame-benchmarking-cli = "33.0.0"
-frame-executive = { version = "29.0.0", default-features = false }
-frame-support = { version = "29.0.0", default-features = false }
-frame-system = { version = "29.0.0", default-features = false }
-frame-system-benchmarking = { version = "29.0.0", default-features = false }
-frame-system-rpc-runtime-api = { version = "27.0.0", default-features = false }
-frame-try-runtime = { version = "0.35.0", default-features = false }
-pallet-aura = { version = "28.0.0", default-features = false }
-pallet-authorship = { version = "29.0.0", default-features = false }
-pallet-balances = { version = "29.0.0", default-features = false }
-pallet-message-queue = { version = "32.0.0", default-features = false }
-pallet-session = { version = "29.0.0", default-features = false }
-pallet-sudo = { version = "29.0.0", default-features = false }
-pallet-timestamp = { version = "28.0.0", default-features = false }
-pallet-transaction-payment = { version = "29.0.0", default-features = false }
-pallet-transaction-payment-rpc = "31.0.0"
-pallet-transaction-payment-rpc-runtime-api = { version = "29.0.0", default-features = false }
-sp-api = { version = "27.0.0", default-features = false }
-sp-block-builder = { version = "27.0.0", default-features = false }
-sp-blockchain = "29.0.0"
-sp-consensus-aura = { version = "0.33.0", default-features = false }
-sp-core = { version = "29.0.0", default-features = false }
-sp-keystore = "0.35.0"
-sp-io = { version = "31.0.0", default-features = false }
-sp-genesis-builder = { version = "0.8.0", default-features = false }
-sp-inherents = { version = "27.0.0", default-features = false }
-sp-offchain = { version = "27.0.0", default-features = false }
-sp-runtime = { version = "32.0.0", default-features = false }
-sp-timestamp = "27.0.0"
-substrate-frame-rpc-system = "29.0.0"
+sc-basic-authorship = "0.36.0"
+sc-chain-spec = "29.0.0"
+sc-cli = "0.38.0"
+sc-client-api = "30.0.0"
+sc-offchain = "31.0.0"
+sc-consensus = "0.35.0"
+sc-executor = "0.34.0"
+sc-network = "0.36.0"
+sc-network-sync = "0.35.0"
+sc-rpc = "31.0.0"
+sc-service = "0.37.0"
+sc-sysinfo = "29.0.0"
+sc-telemetry = "17.0.0"
+sc-tracing = "30.0.0"
+sc-transaction-pool = "30.0.0"
+sc-transaction-pool-api = "30.0.0"
+frame-benchmarking = { version = "30.0.0", default-features = false }
+frame-benchmarking-cli = "34.0.0"
+frame-executive = { version = "30.0.0", default-features = false }
+frame-support = { version = "30.0.0", default-features = false }
+frame-system = { version = "30.0.0", default-features = false }
+frame-system-benchmarking = { version = "30.0.0", default-features = false }
+frame-system-rpc-runtime-api = { version = "28.0.0", default-features = false }
+frame-try-runtime = { version = "0.36.0", default-features = false }
+pallet-aura = { version = "29.0.0", default-features = false }
+pallet-authorship = { version = "30.0.0", default-features = false }
+pallet-balances = { version = "30.0.0", default-features = false }
+pallet-message-queue = { version = "33.0.0", default-features = false }
+pallet-session = { version = "30.0.0", default-features = false }
+pallet-sudo = { version = "30.0.0", default-features = false }
+pallet-timestamp = { version = "29.0.0", default-features = false }
+pallet-transaction-payment = { version = "30.0.0", default-features = false }
+pallet-transaction-payment-rpc = "32.0.0"
+pallet-transaction-payment-rpc-runtime-api = { version = "30.0.0", default-features = false }
+sp-api = { version = "28.0.0", default-features = false }
+sp-block-builder = { version = "28.0.0", default-features = false }
+sp-blockchain = "30.0.0"
+sp-consensus-aura = { version = "0.34.0", default-features = false }
+sp-core = { version = "30.0.0", default-features = false }
+sp-keystore = "0.36.0"
+sp-io = { version = "32.0.0", default-features = false }
+sp-genesis-builder = { version = "0.9.0", default-features = false }
+sp-inherents = { version = "28.0.0", default-features = false }
+sp-offchain = { version = "28.0.0", default-features = false }
+sp-runtime = { version = "33.0.0", default-features = false }
+sp-timestamp = "28.0.0"
+substrate-frame-rpc-system = "30.0.0"
 substrate-prometheus-endpoint = "0.17.0"
-sp-session = { version = "28.0.0", default-features = false }
+sp-session = { version = "29.0.0", default-features = false }
 sp-std = { version = "14.0.0", default-features = false }
-sp-transaction-pool = { version = "27.0.0", default-features = false }
-sp-version = { version = "30.0.0", default-features = false }
+sp-transaction-pool = { version = "28.0.0", default-features = false }
+sp-version = { version = "31.0.0", default-features = false }
 
 # Polkadot
-pallet-xcm = { version = "8.0.3", default-features = false }
-polkadot-cli = "8.0.0"
-polkadot-parachain-primitives = { version = "7.0.0", default-features = false }
-polkadot-primitives = "8.0.1"
-xcm = { package = "staging-xcm", version = "8.0.1", default-features = false }
-polkadot-runtime-common = { version = "8.0.1", default-features = false }
-xcm-builder = { package = "staging-xcm-builder", version = "8.0.1", default-features = false }
-xcm-executor = { package = "staging-xcm-executor", version = "8.0.1", default-features = false }
+pallet-xcm = { version = "9.0.0", default-features = false }
+polkadot-cli = "9.0.0"
+polkadot-parachain-primitives = { version = "8.0.0", default-features = false }
+polkadot-primitives = "9.0.0"
+xcm = { package = "staging-xcm", version = "9.0.0", default-features = false }
+polkadot-runtime-common = { version = "9.0.0", default-features = false }
+xcm-builder = { package = "staging-xcm-builder", version = "9.0.0", default-features = false }
+xcm-executor = { package = "staging-xcm-executor", version = "9.0.1", default-features = false }
 
 # Cumulus
-cumulus-pallet-aura-ext = { version = "0.8.0", default-features = false }
-cumulus-pallet-parachain-system = { version = "0.8.1", default-features = false, features = ["parameterized-consensus-hook"] }
-cumulus-pallet-session-benchmarking = { version = "10.0.0", default-features = false }
-cumulus-pallet-xcm = { version = "0.8.0", default-features = false }
-cumulus-pallet-xcmp-queue = { version = "0.8.0", default-features = false }
-cumulus-primitives-aura = { version = "0.8.0", default-features = false }
-cumulus-primitives-core = { version = "0.8.0", default-features = false }
-cumulus-primitives-utility = { version = "0.8.1", default-features = false }
-pallet-collator-selection = { version = "10.0.0", default-features = false }
-parachains-common = { version = "8.0.0", default-features = false }
-parachain-info = { package = "staging-parachain-info", version = "0.8.0", default-features = false }
-cumulus-primitives-parachain-inherent = "0.8.0"
-cumulus-relay-chain-interface = "0.8.0"
+cumulus-pallet-aura-ext = { version = "0.9.0", default-features = false }
+cumulus-pallet-parachain-system = { version = "0.9.0", default-features = false, features = ["parameterized-consensus-hook"] }
+cumulus-pallet-session-benchmarking = { version = "11.0.0", default-features = false }
+cumulus-pallet-xcm = { version = "0.9.0", default-features = false }
+cumulus-pallet-xcmp-queue = { version = "0.9.0", default-features = false }
+cumulus-primitives-aura = { version = "0.9.0", default-features = false }
+cumulus-primitives-core = { version = "0.9.0", default-features = false }
+cumulus-primitives-utility = { version = "0.9.0", default-features = false }
+pallet-collator-selection = { version = "11.0.0", default-features = false }
+parachains-common = { version = "9.0.0", default-features = false }
+parachain-info = { package = "staging-parachain-info", version = "0.9.0", default-features = false }
+cumulus-primitives-parachain-inherent = "0.9.0"
+cumulus-relay-chain-interface = "0.9.0"
 color-print = "0.3.4"
-cumulus-client-cli = "0.8.0"
-cumulus-client-collator = "0.8.0"
-cumulus-client-consensus-aura = "0.8.0"
-cumulus-client-consensus-common = "0.8.0"
-cumulus-client-consensus-proposer = "0.8.0"
-cumulus-client-service = "0.8.0"
+cumulus-client-cli = "0.9.0"
+cumulus-client-collator = "0.9.0"
+cumulus-client-consensus-aura = "0.9.0"
+cumulus-client-consensus-common = "0.9.0"
+cumulus-client-consensus-proposer = "0.9.0"
+cumulus-client-service = "0.9.0"

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -183,7 +183,7 @@ pub fn run() -> Result<()> {
 			match cmd {
 				BenchmarkCmd::Pallet(cmd) =>
 					if cfg!(feature = "runtime-benchmarks") {
-						runner.sync_run(|config| cmd.run::<Block, ()>(config))
+						runner.sync_run(|config| cmd.run::<sp_runtime::traits::HashingFor<Block>, ()>(config))
 					} else {
 						Err("Benchmarking wasn't enabled when building the node. \
 					You can enable it with `--features runtime-benchmarks`."

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -381,8 +381,6 @@ fn start_consensus(
 	// NOTE: because we use Aura here explicitly, we can use `CollatorSybilResistance::Resistant`
 	// when starting the network.
 
-	let slot_duration = cumulus_client_consensus_aura::slot_duration(&*client)?;
-
 	let proposer_factory = sc_basic_authorship::ProposerFactory::with_proof_recording(
 		task_manager.spawn_handle(),
 		client.clone(),
@@ -414,7 +412,6 @@ fn start_consensus(
 		collator_key,
 		para_id,
 		overseer_handle,
-		slot_duration,
 		relay_chain_slot_duration,
 		proposer,
 		collator_service,

--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -12,15 +12,13 @@ use pallet_xcm::XcmPassthrough;
 use polkadot_parachain_primitives::primitives::Sibling;
 use polkadot_runtime_common::impls::ToAuthor;
 use xcm::latest::prelude::*;
-#[allow(deprecated)]
-use xcm_builder::CurrencyAdapter;
 use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowTopLevelPaidExecutionFrom,
 	DenyReserveTransferToRelayChain, DenyThenTry, EnsureXcmOrigin, FixedWeightBounds,
-	FrameTransactionalProcessor, IsConcrete, NativeAsset, ParentIsPreset, RelayChainAsNative,
-	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
-	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId,
-	UsingComponents, WithComputedOrigin, WithUniqueTopic,
+	FrameTransactionalProcessor, FungibleAdapter, IsConcrete, NativeAsset, ParentIsPreset,
+	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
+	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
+	TrailingSetTopicAsId, UsingComponents, WithComputedOrigin, WithUniqueTopic,
 };
 use xcm_executor::XcmExecutor;
 
@@ -44,8 +42,7 @@ pub type LocationToAccountId = (
 );
 
 /// Means for transacting assets on this chain.
-#[allow(deprecated)]
-pub type LocalAssetTransactor = CurrencyAdapter<
+pub type LocalAssetTransactor = FungibleAdapter<
 	// Use this currency:
 	Balances,
 	// Use this currency when it is a fungible asset matching the given location or name:


### PR DESCRIPTION
Updated to Polkadot v1.8 based on https://github.com/paritytech/polkadot-sdk/blob/release-crates-io-v1.8.0