### PR TITLE
fix: update default para id

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -73,7 +73,7 @@ pub fn development_config() -> ChainSpec {
         Extensions {
             relay_chain: "rococo-local".into(),
             // You MUST set this to the correct network!
-            para_id: 1000,
+            para_id: 2000,
         },
     )
     .with_name("Development")
@@ -106,7 +106,7 @@ pub fn development_config() -> ChainSpec {
             get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
         ],
         get_account_id_from_seed::<sr25519::Public>("Alice"),
-        1000.into(),
+        2000.into(),
     ))
     .build()
 }
@@ -124,7 +124,7 @@ pub fn local_testnet_config() -> ChainSpec {
         Extensions {
             relay_chain: "rococo-local".into(),
             // You MUST set this to the correct network!
-            para_id: 1000,
+            para_id: 2000,
         },
     )
     .with_name("Local Testnet")
@@ -157,7 +157,7 @@ pub fn local_testnet_config() -> ChainSpec {
             get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
         ],
         get_account_id_from_seed::<sr25519::Public>("Alice"),
-        1000.into(),
+        2000.into(),
     ))
     .with_protocol_id("template-local")
     .with_properties(properties)


### PR DESCRIPTION
Simply updates the default para id to the public start index: https://github.com/paritytech/polkadot-sdk/blob/6fdb522ded3813f43a539964af78d5fc6d9f1e97/polkadot/parachain/src/primitives.rs#L204