### PR TITLE
fix: Revert relay number check

### DIFF
--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -27,7 +27,7 @@
 mod xcm_config;
 
 // Substrate and Polkadot dependencies
-use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
+use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use frame_support::{
     derive_impl,
@@ -195,7 +195,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
     type ReservedDmpWeight = ReservedDmpWeight;
     type XcmpMessageHandler = XcmpQueue;
     type ReservedXcmpWeight = ReservedXcmpWeight;
-    type CheckAssociatedRelayNumber = RelayNumberStrictlyIncreases;
+    type CheckAssociatedRelayNumber = RelayNumberMonotonicallyIncreases;
     type ConsensusHook = ConsensusHook;
 }
 


### PR DESCRIPTION
It seems that we included a regression.

We configured `CheckAssociatedRelayNumber = RelayNumberStrictlyIncreases` while using the `lookahead` collator:

> This changed combined with the fact that you are using the lookahead collator and async backing, you run into this error message. The lookahead collator is building multiple parachain blocks on the same relay chain block. This leads to this issue, as the relay chain number is not strictly increasing between parachain blocks. Reverting this change will fix it.

- [stack exchange solution](https://substrate.stackexchange.com/a/11572/165)

---

I considered introducing a test for this, so we can verify such a regression is not included in future changes. But being the "base-parachain" and the one we are using to maintain the rest of our templates now and generate them in the future, that felt like maybe too much of an opinion to make.