### PR TITLE
fix: add missing feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8486,6 +8486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f276b38deaab6bff3ddfe061331901196ff992f76398bd0abc78382f4f115cf0"
 dependencies = [
  "async-trait",
+ "bitvec",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "frame-support",
@@ -8541,6 +8542,7 @@ dependencies = [
  "polkadot-runtime-parachains",
  "polkadot-statement-distribution",
  "rococo-runtime",
+ "rococo-runtime-constants",
  "sc-authority-discovery",
  "sc-basic-authorship",
  "sc-block-builder",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -60,7 +60,7 @@ substrate-frame-rpc-system.workspace = true
 substrate-prometheus-endpoint.workspace = true
 
 # Polkadot
-polkadot-cli.workspace = true
+polkadot-cli = { workspace = true, features = ["rococo-native"] }
 polkadot-primitives.workspace = true
 xcm.workspace = true
 
@@ -78,17 +78,17 @@ cumulus-relay-chain-interface.workspace = true
 [features]
 default = []
 runtime-benchmarks = [
-	"cumulus-primitives-core/runtime-benchmarks",
-	"frame-benchmarking-cli/runtime-benchmarks",
-	"frame-benchmarking/runtime-benchmarks",
-	"parachain-template-runtime/runtime-benchmarks",
-	"polkadot-cli/runtime-benchmarks",
-	"polkadot-primitives/runtime-benchmarks",
-	"sc-service/runtime-benchmarks",
-	"sp-runtime/runtime-benchmarks",
+    "cumulus-primitives-core/runtime-benchmarks",
+    "frame-benchmarking-cli/runtime-benchmarks",
+    "frame-benchmarking/runtime-benchmarks",
+    "parachain-template-runtime/runtime-benchmarks",
+    "polkadot-cli/runtime-benchmarks",
+    "polkadot-primitives/runtime-benchmarks",
+    "sc-service/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
 ]
 try-runtime = [
-	"parachain-template-runtime/try-runtime",
-	"polkadot-cli/try-runtime",
-	"sp-runtime/try-runtime",
+    "parachain-template-runtime/try-runtime",
+    "polkadot-cli/try-runtime",
+    "sp-runtime/try-runtime",
 ]


### PR DESCRIPTION
The switch to workspace dependencies in https://github.com/r0gue-io/base-parachain/commit/78ca0fdd5d2055c90f0c3607c039e5b125816c8e lost the `rococo-native` feature in `node/Cargo.toml`, effectively resulting in an error when running with `--dev`.

![image](https://github.com/r0gue-io/base-parachain/assets/60948618/d29b9043-460b-4caa-ad05-c291894f6a63)

This PR simply restores the feature in line with the primary Cumulus parachain template upstream.