### PR TITLE
feat: liquid template with custom naming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,16 @@ serde = "1.0.197"
 serde_json = "1.0.114"
 smallvec = "1.11.2"
 
+
+
+
+
+{{project-name}}-runtime = { path = "./runtime" }
+
 # Build
 substrate-build-script-utils = "11.0.0"
 substrate-wasm-builder = "22.0.0"
-
 # Local
-parachain-template-runtime = { path = "./runtime" }
-
 # Substrate
 frame-benchmarking = { version = "34.0.0", default-features = false }
 frame-benchmarking-cli = "38.0.0"

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,29 @@
+[template]
+
+include = [
+    "Cargo.toml",
+    "node/src/chain_spec.rs",
+    "node/src/cli.rs",
+    "node/src/command.rs",
+    "node/src/rpc.rs",
+    "node/src/service.rs",
+    "runtime/Cargo.toml",
+    "runtime/src/lib.rs",
+    "network.toml",
+]
+exclude = [
+    "Cargo.lock",
+    "node/build.rs",
+    "node/src/main.rs",
+    "runtime/build.rs",
+    "runtime/src/configs/*",
+    "runtime/src/weights/*",
+    "runtime/src/apis.rs",
+    "runtime/src/benchmarks.rs",
+    "target/*",
+    "LICENSE",
+    "README.md",
+    "rust-toolchain.toml",
+    ".gitignore",
+    ".github",
+]

--- a/network.toml
+++ b/network.toml
@@ -1,0 +1,17 @@
+[relaychain]
+chain = "rococo-local"
+
+[[relaychain.nodes]]
+name = "alice"
+validator = true
+
+[[relaychain.nodes]]
+name = "bob"
+validator = true
+
+[[parachains]]
+id = 2000
+default_command = "./target/release/{{project-name}}-node"
+
+[[parachains.collators]]
+name = "collator-01"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "parachain-template-node"
+name = "{{project-name}}-node"
 version = "0.1.0"
 authors.workspace = true
-description = "Parachain node template"
+description = "{{project-name}} Node"
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -25,8 +25,9 @@ log.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 
-# Local
-parachain-template-runtime.workspace = true
+
+#Local
+{{project-name}}-runtime.workspace = true
 
 # Substrate
 frame-benchmarking.workspace = true
@@ -82,14 +83,14 @@ runtime-benchmarks = [
     "cumulus-primitives-core/runtime-benchmarks",
     "frame-benchmarking-cli/runtime-benchmarks",
     "frame-benchmarking/runtime-benchmarks",
-    "parachain-template-runtime/runtime-benchmarks",
+    "{{project-name}}-runtime/runtime-benchmarks",
     "polkadot-cli/runtime-benchmarks",
     "polkadot-primitives/runtime-benchmarks",
     "sc-service/runtime-benchmarks",
     "sp-runtime/runtime-benchmarks",
 ]
 try-runtime = [
-    "parachain-template-runtime/try-runtime",
+    "{{project-name}}-runtime/try-runtime",
     "polkadot-cli/try-runtime",
     "sp-runtime/try-runtime",
 ]

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,5 +1,5 @@
 use cumulus_primitives_core::ParaId;
-use parachain_template_runtime as runtime;
+use {{crate_name}}_runtime as runtime;
 use runtime::{AccountId, AuraId, Signature, EXISTENTIAL_DEPOSIT};
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
@@ -58,7 +58,7 @@ where
 /// Generate the session keys from individual elements.
 ///
 /// The input must be a tuple of individual keys (a single arg for now since we have just one key).
-pub fn template_session_keys(keys: AuraId) -> runtime::SessionKeys {
+pub fn {{crate_name}}_session_keys(keys: AuraId) -> runtime::SessionKeys {
     runtime::SessionKeys { aura: keys }
 }
 
@@ -160,7 +160,7 @@ pub fn local_testnet_config() -> ChainSpec {
         get_account_id_from_seed::<sr25519::Public>("Alice"),
         2000.into(),
     ))
-    .with_protocol_id("template-local")
+    .with_protocol_id("{{crate_name}}-local")
     .with_properties(properties)
     .build()
 }
@@ -189,7 +189,7 @@ fn testnet_genesis(
                     (
                         acc.clone(),                 // account id
                         acc,                         // validator id
-                        template_session_keys(aura), // session keys
+                        {{crate_name}}_session_keys(aura), // session keys
                     )
                 })
             .collect::<Vec<_>>(),

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -42,13 +42,13 @@ pub enum Subcommand {
 
 const AFTER_HELP_EXAMPLE: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</></>
-   <bold>parachain-template-node build-spec --disable-default-bootnode > plain-parachain-chainspec.json</>
+   <bold>{{project-name}}-node build-spec --disable-default-bootnode > plain-parachain-chainspec.json</>
            Export a chainspec for a local testnet in json format.
-   <bold>parachain-template-node --chain plain-parachain-chainspec.json --tmp -- --chain rococo-local</>
+   <bold>{{project-name}}-node --chain plain-parachain-chainspec.json --tmp -- --chain rococo-local</>
            Launch a full node with chain specification loaded from plain-parachain-chainspec.json.
-   <bold>parachain-template-node</>
+   <bold>{{project-name}}-node</>
            Launch a full node with default parachain <italic>local-testnet</> and relay chain <italic>rococo-local</>.
-   <bold>parachain-template-node --collator</>
+   <bold>{{project-name}}-node --collator</>
            Launch a collator with default parachain <italic>local-testnet</> and relay chain <italic>rococo-local</>.
  "#
 );

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -4,7 +4,7 @@ use cumulus_client_service::storage_proof_size::HostFunctions as ReclaimHostFunc
 use cumulus_primitives_core::ParaId;
 use frame_benchmarking_cli::{BenchmarkCmd, SUBSTRATE_REFERENCE_HARDWARE};
 use log::info;
-use parachain_template_runtime::Block;
+use {{crate_name}}_runtime::Block;
 use sc_cli::{
     ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams,
     NetworkParams, Result, SharedParams, SubstrateCli,
@@ -30,7 +30,7 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 
 impl SubstrateCli for Cli {
     fn impl_name() -> String {
-        "Parachain Collator Template".into()
+        "{{project-name}}".into()
     }
 
     fn impl_version() -> String {
@@ -39,7 +39,7 @@ impl SubstrateCli for Cli {
 
     fn description() -> String {
         format!(
-            "Parachain Collator Template\n\nThe command-line arguments provided first will be \
+            "{{project-name}}\n\nThe command-line arguments provided first will be \
 		passed to the parachain node, while the arguments provided after -- will be passed \
 		to the relay chain node.\n\n\
 		{} <parachain-args> -- <relay-chain-args>",
@@ -66,7 +66,7 @@ impl SubstrateCli for Cli {
 
 impl SubstrateCli for RelayChainCli {
     fn impl_name() -> String {
-        "Parachain Collator Template".into()
+        "{{project-name}}".into()
     }
 
     fn impl_version() -> String {
@@ -75,7 +75,7 @@ impl SubstrateCli for RelayChainCli {
 
     fn description() -> String {
         format!(
-            "Parachain Collator Template\n\nThe command-line arguments provided first will be \
+            "{{project-name}}\n\nThe command-line arguments provided first will be \
 		passed to the parachain node, while the arguments provided after -- will be passed \
 		to the relay chain node.\n\n\
 		{} <parachain-args> -- <relay-chain-args>",
@@ -100,19 +100,10 @@ impl SubstrateCli for RelayChainCli {
     }
 }
 
-macro_rules! construct_async_run {
-	(|$components:ident, $cli:ident, $cmd:ident, $config:ident| $( $code:tt )* ) => {{
-		let runner = $cli.create_runner($cmd)?;
-		runner.async_run(|$config| {
-			let $components = new_partial(&$config)?;
-			let task_manager = $components.task_manager;
-			{ $( $code )* }.map(|v| (v, task_manager))
-		})
-	}}
-}
-
 /// Parse command line arguments into service configuration.
 pub fn run() -> Result<()> {
+    use crate::construct_async_run;
+
     let cli = Cli::from_args();
 
     match &cli.subcommand {

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -7,6 +7,7 @@ mod cli;
 mod command;
 mod rpc;
 mod service;
+mod utils;
 
 fn main() -> sc_cli::Result<()> {
     command::run()

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use parachain_template_runtime::{opaque::Block, AccountId, Balance, Nonce};
+use {{crate_name}}_runtime::{opaque::Block, AccountId, Balance, Nonce};
 
 pub use sc_rpc::DenyUnsafe;
 use sc_transaction_pool_api::TransactionPool;

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -5,7 +5,7 @@ use std::{sync::Arc, time::Duration};
 
 use cumulus_client_cli::CollatorOptions;
 // Local Runtime Types
-use parachain_template_runtime::{
+use {{crate_name}}_runtime::{
     apis::RuntimeApi,
     opaque::{Block, Hash},
 };

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -1,0 +1,14 @@
+pub mod utils {
+    #[macro_export]
+    #[doc(hidden)]
+    macro_rules! construct_async_run {
+    	(|$components:ident, $cli:ident, $cmd:ident, $config:ident| $( $code:tt )* ) => {{
+    		let runner = $cli.create_runner($cmd)?;
+    		runner.async_run(|$config| {
+    			let $components = new_partial(&$config)?;
+    			let task_manager = $components.task_manager;
+    			{ $( $code )* }.map(|v| (v, task_manager))
+    		})
+    	}}
+    }
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "parachain-template-runtime"
+name = "{{project-name}}-runtime"
 version = "0.1.0"
 authors.workspace = true
-description = "Parachain runtime template"
+description = "{{project-name}} Runtime"
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -182,8 +182,8 @@ impl_opaque_keys! {
 
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-    spec_name: create_runtime_str!("parachain-template-runtime"),
-    impl_name: create_runtime_str!("parachain-template-runtime"),
+    spec_name: create_runtime_str!("{{project-name}}-runtime"),
+    impl_name: create_runtime_str!("{{project-name}}-runtime"),
     authoring_version: 1,
     spec_version: 1,
     impl_version: 0,


### PR DESCRIPTION
This PR adapts base-parachain so it becomes a liquid template that can be used by tooling like pop-cli to bootstrap user projects.

- User given name will be applied to the node, runtime, resulting binary and a few configurations in the respective Cargo files and `network.toml`. 

Downsides:

- This change makes `base-parachain` move away from being a rust project, cargo will error out as the syntax used for the template won't make it "cargo compliant".
- Maintenance of this template, like upgrading it to new polkadot-sdk versions, might be a tad more painful because of the above.

Note:

- With the sight set on omni-node advancements, we might/should get rid of everything node from this template. Making the maintenance not that big of a problem. And so, making it wort it to advance in this direction and evolve the template.