### PR TITLE
chore: bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 
 [workspace.dependencies]
 clap = { version = "4.5.3", features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = [
     "derive",
 ] }
 color-print = "0.3.4"
@@ -22,7 +22,7 @@ docify = "0.2.8"
 futures = "0.3.30"
 hex-literal = "0.4.1"
 jsonrpsee = { version = "0.23.2", features = ["server"] }
-log = { version = "0.4.20", default-features = false }
+log = { version = "0.4.21", default-features = false }
 scale-info = { version = "2.11.1", default-features = false, features = [
     "derive",
 ] }


### PR DESCRIPTION
A nitpick but now everything is line with the 1.14 release