### PR TITLE
ci: enable metadata hash feature in release builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           protoc --version
+
       - name: Install dependencies (macOS)
         if: contains(matrix.platform.target, 'apple')
         run: |
@@ -60,7 +61,7 @@ jobs:
         run: rustup target add ${{ matrix.platform.target }}
 
       - name: Build node
-        run: cargo build --release -p parachain-template-node --target ${{ matrix.platform.target }}
+        run: cargo build --release -p parachain-template-node --target ${{ matrix.platform.target }} --features parachain-template-runtime/on-chain-release-build
 
       - name: Package binary
         run: |


### PR DESCRIPTION
Closes #62.

This PR builds the runtime with the `metadata-hash` feature in the release CI.